### PR TITLE
Bookmarks: position-anchored, hotkey slots, placeholder

### DIFF
--- a/mdv.xcodeproj/project.pbxproj
+++ b/mdv.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AA000004 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = BA000002 /* MarkdownUI */; };
 		AA000005 /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = AB000006; };
 		AA000007 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000007; };
+		AA000008 /* BookmarksManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000008; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +24,7 @@
 		AB000005 /* mdv.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = mdv.entitlements; sourceTree = "<group>"; };
 		AB000006 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		AB000007 /* Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database.swift; sourceTree = "<group>"; };
+		AB000008 /* BookmarksManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksManager.swift; sourceTree = "<group>"; };
 		AB000010 /* mdv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = mdv.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -64,6 +66,7 @@
 				AB000002 /* ContentView.swift */,
 				AB000003 /* HistoryManager.swift */,
 				AB000007 /* Database.swift */,
+				AB000008 /* BookmarksManager.swift */,
 				AB000004 /* Info.plist */,
 				AB000005 /* mdv.entitlements */,
 				AB000006 /* AppIcon.icns */,
@@ -142,6 +145,7 @@
 				AA000002 /* ContentView.swift in Sources */,
 				AA000003 /* HistoryManager.swift in Sources */,
 				AA000007 /* Database.swift in Sources */,
+				AA000008 /* BookmarksManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mdv/BookmarksManager.swift
+++ b/mdv/BookmarksManager.swift
@@ -1,0 +1,178 @@
+import Foundation
+import SwiftUI
+
+/// In-memory representation of a user bookmark.
+///
+/// Bookmarks anchor to a position inside the file (`blockIndex` plus a
+/// `blockFingerprint` that lets us re-locate the spot if the file gets edited
+/// and indices shift). Multiple bookmarks per file are allowed — markdown docs
+/// can be huge, and bookmarks are the in-doc navigation primitive.
+///
+/// `fileExists` is recomputed at load and on demand; bookmarks survive even
+/// when the underlying file disappears, but get visually dimmed.
+struct Bookmark: Identifiable, Hashable {
+    let id: Int64
+    let path: String
+    var title: String
+    var sortOrder: Int
+    let createdAt: Date
+    let blockIndex: Int
+    let blockFingerprint: String
+    var fileExists: Bool
+}
+
+/// Owns the user's saved bookmarks.
+///
+/// "Slot" is implicit — the first five entries in `bookmarks` are the ⌘1…⌘5
+/// hotkeys. Reordering the list is the only way to change which bookmark
+/// owns which hotkey, which keeps the model dead simple.
+///
+/// The ⌘0 *placeholder* is intentionally NOT managed here. It's transient
+/// per-window state owned by ContentView — see the Placeholder section there.
+final class BookmarksManager: ObservableObject {
+    @Published private(set) var bookmarks: [Bookmark] = []
+
+    static let maxSlots = 5
+
+    init() {
+        reload()
+    }
+
+    func reload() {
+        let rows = Database.shared.loadBookmarks()
+        bookmarks = rows.map { row in
+            Bookmark(
+                id: row.id,
+                path: row.path,
+                title: row.title,
+                sortOrder: row.sortOrder,
+                createdAt: row.createdAt,
+                blockIndex: row.blockIndex,
+                blockFingerprint: row.blockFingerprint,
+                fileExists: FileManager.default.fileExists(atPath: row.path)
+            )
+        }
+    }
+
+    func refreshFileExistence() {
+        for i in bookmarks.indices {
+            bookmarks[i].fileExists = FileManager.default.fileExists(atPath: bookmarks[i].path)
+        }
+    }
+
+    /// True if this file has at least one bookmark anywhere. Used by the
+    /// toolbar indicator (filled vs hollow icon) — multiple bookmarks per file
+    /// are allowed, so this is a binary "any" test rather than a toggle.
+    func hasAnyBookmark(forPath path: String) -> Bool {
+        bookmarks.contains { $0.path == path }
+    }
+
+    @discardableResult
+    func add(path: String, title: String, blockIndex: Int, fingerprint: String) -> Bookmark? {
+        let nextOrder = bookmarks.count
+        guard let row = Database.shared.addBookmark(
+            path: path,
+            title: title,
+            sortOrder: nextOrder,
+            blockIndex: blockIndex,
+            blockFingerprint: fingerprint
+        ) else { return nil }
+        let bookmark = Bookmark(
+            id: row.id,
+            path: row.path,
+            title: row.title,
+            sortOrder: row.sortOrder,
+            createdAt: row.createdAt,
+            blockIndex: row.blockIndex,
+            blockFingerprint: row.blockFingerprint,
+            fileExists: FileManager.default.fileExists(atPath: row.path)
+        )
+        bookmarks.append(bookmark)
+        return bookmark
+    }
+
+    func remove(id: Int64) {
+        Database.shared.removeBookmark(id: id)
+        bookmarks.removeAll { $0.id == id }
+        renormalizeSortOrders()
+    }
+
+    func move(from source: IndexSet, to destination: Int) {
+        bookmarks.move(fromOffsets: source, toOffset: destination)
+        renormalizeSortOrders()
+    }
+
+    /// Drag-drop entry point: move a bookmark by id to a target index.
+    /// Used by the BookmarkDropDelegate where IndexSet semantics don't apply.
+    func moveBookmark(id: Int64, toIndex destination: Int) {
+        guard let from = bookmarks.firstIndex(where: { $0.id == id }) else { return }
+        let clamped = max(0, min(destination, bookmarks.count - 1))
+        guard from != clamped else { return }
+        let item = bookmarks.remove(at: from)
+        bookmarks.insert(item, at: clamped)
+        renormalizeSortOrders()
+    }
+
+    /// Move a bookmark to the very end of the list (used when the user drops
+    /// onto the tail spacer below the last row).
+    func moveBookmarkToEnd(id: Int64) {
+        guard let from = bookmarks.firstIndex(where: { $0.id == id }) else { return }
+        guard from != bookmarks.count - 1 else { return }
+        let item = bookmarks.remove(at: from)
+        bookmarks.append(item)
+        renormalizeSortOrders()
+    }
+
+    /// 1-based slot number (1…5) if this bookmark is in a hotkey slot, else nil.
+    func slotIndex(for bookmarkID: Int64) -> Int? {
+        guard let i = bookmarks.firstIndex(where: { $0.id == bookmarkID }) else { return nil }
+        return i < BookmarksManager.maxSlots ? i + 1 : nil
+    }
+
+    /// Look up the bookmark in slot `n` (1-based). Returns nil if the slot is empty.
+    func bookmark(forSlot n: Int) -> Bookmark? {
+        let i = n - 1
+        guard i >= 0, i < min(BookmarksManager.maxSlots, bookmarks.count) else { return nil }
+        return bookmarks[i]
+    }
+
+    private func renormalizeSortOrders() {
+        for i in bookmarks.indices {
+            bookmarks[i].sortOrder = i
+        }
+        Database.shared.setBookmarkOrder(idsInOrder: bookmarks.map { $0.id })
+    }
+}
+
+// MARK: - Anchor matching
+
+/// Normalize a chunk of markdown into a fingerprint. We strip excess whitespace
+/// and lowercase so small editing diffs (added trailing spaces, casing tweaks
+/// inside a heading) don't break the anchor.
+func bookmarkFingerprint(forBlock block: String) -> String {
+    let collapsed = block
+        .components(separatedBy: .whitespacesAndNewlines)
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+        .lowercased()
+    return String(collapsed.prefix(80))
+}
+
+/// Resolve a bookmark's anchor against a document's current blocks. Returns the
+/// best-matching block index. Strategy: exact fingerprint match wins; failing
+/// that we fall back to the stored block index, clamped to the doc's bounds.
+func resolveBookmarkAnchor(
+    blocks: [String],
+    storedIndex: Int,
+    fingerprint: String
+) -> Int {
+    guard !blocks.isEmpty else { return 0 }
+    if !fingerprint.isEmpty {
+        for (i, block) in blocks.enumerated() {
+            if bookmarkFingerprint(forBlock: block) == fingerprint {
+                return i
+            }
+        }
+    }
+    return max(0, min(storedIndex, blocks.count - 1))
+}

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -59,6 +59,16 @@ struct ContentView: View {
     }
     @State private var placeholder: PlaceholderAnchor? = nil
 
+    /// Highlights "the bookmark you're currently on" in the panel. Set by
+    /// loadBookmark / addBookmarkAtCurrentSpot; cleared by any non-bookmark
+    /// file-open path (history click, drag-drop, ⌘O, Open-URL).
+    @State private var currentBookmarkID: Int64? = nil
+    /// Same idea for the ⌘0 placeholder row.
+    @State private var placeholderIsCurrent: Bool = false
+    /// Suppresses the clear-on-selectedEntry-change in onChange while a
+    /// bookmark navigation is in flight (which itself flips selectedEntry).
+    @State private var bookmarkNavInProgress: Bool = false
+
     struct TOCHeading: Identifiable {
         let level: Int
         let text: String
@@ -239,6 +249,13 @@ struct ContentView: View {
             handleDrop(providers)
         }
         .onChange(of: selectedEntry) { _ in
+            // Selection changed by something other than a bookmark/placeholder
+            // jump? Then drop the "active bookmark" highlight.
+            if !bookmarkNavInProgress {
+                currentBookmarkID = nil
+                placeholderIsCurrent = false
+            }
+            bookmarkNavInProgress = false
             loadCurrentEntry()
         }
         .onChange(of: rawMarkdown) { _ in
@@ -1014,40 +1031,50 @@ struct ContentView: View {
 
     private func placeholderRow(_ p: PlaceholderAnchor) -> some View {
         let missing = !FileManager.default.fileExists(atPath: p.path)
+        let isCurrent = placeholderIsCurrent
         return Button {
             jumpToPlaceholder()
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: "pin.fill")
                     .font(.system(size: 12))
-                    .foregroundStyle(missing ? Color.orange : Color.accentColor)
+                    .foregroundStyle(
+                        missing ? Color.orange :
+                        (isCurrent ? Color.white : Color.accentColor)
+                    )
                     .frame(width: 16)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(p.title)
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(missing ? Color.secondary : Color.primary)
+                        .foregroundStyle(
+                            isCurrent ? Color.white :
+                            (missing ? Color.secondary : Color.primary)
+                        )
                         .lineLimit(1)
                         .truncationMode(.middle)
                     Text(URL(fileURLWithPath: p.path).lastPathComponent)
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(isCurrent ? Color.white.opacity(0.8) : .secondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
                 Spacer(minLength: 4)
-                hotkeyBadge(0, onAccent: false)
+                hotkeyBadge(0, onAccent: isCurrent)
             }
-            .opacity(missing ? 0.6 : 1.0)
+            .opacity(missing && !isCurrent ? 0.6 : 1.0)
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(hoveredPlaceholder ? Color.primary.opacity(0.06) : Color.accentColor.opacity(0.08))
+                    .fill(
+                        isCurrent ? Color.accentColor :
+                        (hoveredPlaceholder ? Color.primary.opacity(0.06) : Color.accentColor.opacity(0.08))
+                    )
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .stroke(Color.accentColor.opacity(0.25), lineWidth: 0.5)
+                    .stroke(isCurrent ? Color.clear : Color.accentColor.opacity(0.25), lineWidth: 0.5)
             )
             .contentShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
         }
@@ -1067,6 +1094,7 @@ struct ContentView: View {
         let hovered = hoveredBookmark == bookmark.id
         let dragging = draggingBookmarkID == bookmark.id
         let dropHover = dropTargetBookmarkID == bookmark.id
+        let isCurrent = currentBookmarkID == bookmark.id
         let filename = URL(fileURLWithPath: bookmark.path).lastPathComponent
 
         return Button {
@@ -1075,34 +1103,41 @@ struct ContentView: View {
             HStack(spacing: 8) {
                 Image(systemName: missing ? "exclamationmark.triangle.fill" : "bookmark.fill")
                     .font(.system(size: 11))
-                    .foregroundStyle(missing ? Color.orange : Color.accentColor.opacity(0.7))
+                    .foregroundStyle(
+                        missing ? Color.orange :
+                        (isCurrent ? Color.white : Color.accentColor.opacity(0.7))
+                    )
                     .frame(width: 16)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(bookmark.title.isEmpty ? "(unnamed)" : bookmark.title)
                         .font(.system(size: 13))
-                        .foregroundStyle(missing ? Color.secondary : Color.primary)
+                        .foregroundStyle(
+                            isCurrent ? Color.white :
+                            (missing ? Color.secondary : Color.primary)
+                        )
                         .lineLimit(1)
                         .truncationMode(.tail)
                     Text(filename)
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(isCurrent ? Color.white.opacity(0.8) : .secondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
                 Spacer(minLength: 4)
                 if let n = slot {
-                    hotkeyBadge(n, onAccent: false)
+                    hotkeyBadge(n, onAccent: isCurrent)
                 }
             }
-            .opacity(missing ? 0.6 : (dragging ? 0.4 : 1.0))
+            .opacity(missing && !isCurrent ? 0.6 : (dragging ? 0.4 : 1.0))
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
                     .fill(
-                        dropHover ? Color.accentColor.opacity(0.18) :
-                        (hovered ? Color.primary.opacity(0.06) : Color.clear)
+                        isCurrent ? Color.accentColor :
+                        (dropHover ? Color.accentColor.opacity(0.18) :
+                        (hovered ? Color.primary.opacity(0.06) : Color.clear))
                     )
             )
             .overlay(alignment: .top) {
@@ -1467,12 +1502,17 @@ struct ContentView: View {
         let block = hoveredBlock ?? topVisibleBlock
         let docBlocks = blocks
         let fp = (block < docBlocks.count) ? bookmarkFingerprint(forBlock: docBlocks[block]) : ""
-        _ = bookmarks.add(
+        let added = bookmarks.add(
             path: entry.path,
             title: bookmarkTitle(forBlockAt: block),
             blockIndex: block,
             fingerprint: fp
         )
+        // The bookmark you just added is the one you're "on."
+        if let id = added?.id {
+            currentBookmarkID = id
+            placeholderIsCurrent = false
+        }
         if bookmarks.bookmarks.count == 1 {
             withAnimation(.easeOut(duration: 0.22)) {
                 bookmarksExpandedRaw = true
@@ -1491,6 +1531,9 @@ struct ContentView: View {
                 return
             }
         }
+        currentBookmarkID = bookmark.id
+        placeholderIsCurrent = false
+        bookmarkNavInProgress = true
         jumpTo(
             path: bookmark.path,
             blockIndex: bookmark.blockIndex,
@@ -1539,6 +1582,13 @@ struct ContentView: View {
             blockIndex: block,
             blockFingerprint: fp
         )
+        placeholderIsCurrent = true
+        currentBookmarkID = nil
+        // Make sure the user actually sees the row that just appeared.
+        withAnimation(.easeOut(duration: 0.22)) {
+            bookmarksExpandedRaw = true
+            inspectorVisible = true
+        }
     }
 
     /// ⌘0: jump to the placeholder if one is set; beep otherwise.
@@ -1547,6 +1597,9 @@ struct ContentView: View {
             NSSound.beep()
             return
         }
+        placeholderIsCurrent = true
+        currentBookmarkID = nil
+        bookmarkNavInProgress = true
         jumpTo(path: p.path, blockIndex: p.blockIndex, fingerprint: p.blockFingerprint)
     }
 

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -226,8 +226,11 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openBookmarkSlot)) { notif in
             if let n = notif.object as? Int { openBookmarkSlot(n) }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .togglePlaceholder)) { _ in
-            togglePlaceholder()
+        .onReceive(NotificationCenter.default.publisher(for: .setPlaceholder)) { _ in
+            setPlaceholder()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .jumpToPlaceholder)) { _ in
+            jumpToPlaceholder()
         }
         .onOpenURL { url in
             loadFile(url)
@@ -1012,7 +1015,7 @@ struct ContentView: View {
     private func placeholderRow(_ p: PlaceholderAnchor) -> some View {
         let missing = !FileManager.default.fileExists(atPath: p.path)
         return Button {
-            togglePlaceholder()
+            jumpToPlaceholder()
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: "pin.fill")
@@ -1052,7 +1055,7 @@ struct ContentView: View {
         .onHover { inside in
             hoveredPlaceholder = inside
         }
-        .help("Placeholder (⌘0): swap back here")
+        .help("Placeholder — ⌘0 to jump here, ⇧⌘0 to overwrite")
         .contextMenu {
             Button("Clear Placeholder") { placeholder = nil }
         }
@@ -1524,27 +1527,27 @@ struct ContentView: View {
         }
     }
 
-    /// ⌘0: flip between current spot and the placeholder.
-    /// - First press (no placeholder set): captures current as placeholder.
-    /// - Subsequent press: jumps to placeholder while saving current as the new placeholder,
-    ///   so a second ⌘0 brings you back. Pure two-position toggle.
-    private func togglePlaceholder() {
+    /// ⇧⌘0: capture current spot as the placeholder. Overwrites any prior value.
+    private func setPlaceholder() {
         guard let entry = selectedEntry else { return }
         let block = hoveredBlock ?? topVisibleBlock
         let docBlocks = blocks
         let fp = (block < docBlocks.count) ? bookmarkFingerprint(forBlock: docBlocks[block]) : ""
-        let current = PlaceholderAnchor(
+        placeholder = PlaceholderAnchor(
             path: entry.path,
             title: bookmarkTitle(forBlockAt: block),
             blockIndex: block,
             blockFingerprint: fp
         )
-        if let prev = placeholder {
-            placeholder = current
-            jumpTo(path: prev.path, blockIndex: prev.blockIndex, fingerprint: prev.blockFingerprint)
-        } else {
-            placeholder = current
+    }
+
+    /// ⌘0: jump to the placeholder if one is set; beep otherwise.
+    private func jumpToPlaceholder() {
+        guard let p = placeholder else {
+            NSSound.beep()
+            return
         }
+        jumpTo(path: p.path, blockIndex: p.blockIndex, fingerprint: p.blockFingerprint)
     }
 
     private func loadCurrentEntry() {

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -4,6 +4,7 @@ import AppKit
 
 struct ContentView: View {
     @EnvironmentObject var history: HistoryManager
+    @EnvironmentObject var bookmarks: BookmarksManager
     let initialURL: URL?
 
     init(initialURL: URL? = nil) {
@@ -15,12 +16,48 @@ struct ContentView: View {
     @State private var sidebarWidth: CGFloat = 240
     @State private var dragHandleHovered = false
 
-    // TOC
-    @State private var tocVisible: Bool = false
+    // TOC + Bookmarks (right inspector)
+    @State private var inspectorVisible: Bool = false
     @State private var tocSelectedBlock: Int? = nil
     @State private var tocScrollTrigger: Int? = nil
     @State private var hoveredHeading: Int? = nil
-    private let tocWidth: CGFloat = 220
+    private let inspectorWidth: CGFloat = 240
+
+    // Bookmarks pane (lives below TOC inside the inspector)
+    @AppStorage("mdv_bookmarks_height") private var bookmarksHeight: Double = 240
+    @AppStorage("mdv_bookmarks_expanded") private var bookmarksExpandedRaw: Bool = false
+    @State private var bookmarksDividerHovered = false
+    @State private var hoveredBookmark: Int64? = nil
+    @State private var draggingBookmarkID: Int64? = nil
+    @State private var dropTargetBookmarkID: Int64? = nil
+    @State private var hoveredPlaceholder = false
+
+    /// Block-indices currently visible in the markdown viewport. Updated via
+    /// each block's .onAppear / .onDisappear. The minimum is the topmost
+    /// visible block, which is what we anchor a new bookmark to.
+    @State private var visibleBlocks: Set<Int> = []
+    /// Block the mouse is currently hovering. Drives the bookmark-anchor
+    /// indicator (subtle accent stripe + tint) so the user can see what
+    /// ⌘D will bookmark — there's no caret in a viewer.
+    @State private var hoveredBlock: Int? = nil
+    /// When non-nil, the markdown view scrolls to this block on next layout.
+    /// Used after loading a file via a bookmark / ⌘0 to land on the anchor.
+    @State private var pendingAnchorBlock: Int? = nil
+    /// Set by jumpTo(...) when the file is being reloaded; consumed once the
+    /// new document's blocks are computed. We can't resolve the fingerprint
+    /// against the document until rawMarkdown updates.
+    @State private var pendingPostLoadAnchor: (blockIndex: Int, fingerprint: String)? = nil
+
+    /// In-memory placeholder slot (⌘0). Holds "the spot I want to flip back to."
+    /// Not persisted — pure per-window navigation state, like Vim's last-jump
+    /// register but bidirectional.
+    struct PlaceholderAnchor: Equatable {
+        let path: String
+        let title: String
+        let blockIndex: Int
+        let blockFingerprint: String
+    }
+    @State private var placeholder: PlaceholderAnchor? = nil
 
     struct TOCHeading: Identifiable {
         let level: Int
@@ -124,14 +161,14 @@ struct ContentView: View {
             markdownView
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            if tocVisible {
+            if inspectorVisible {
                 Divider()
-                tocSidebar
-                    .frame(width: tocWidth)
+                inspectorPanel
+                    .frame(width: inspectorWidth)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
-        .animation(.easeOut(duration: 0.22), value: tocVisible)
+        .animation(.easeOut(duration: 0.22), value: inspectorVisible)
         .navigationTitle(selectedEntry?.filename ?? "mdv")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -142,14 +179,24 @@ struct ContentView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    tocVisible.toggle()
+                    addBookmarkAtCurrentSpot()
                 } label: {
-                    Image(systemName: tocVisible ? "sidebar.right" : "sidebar.right")
-                        .foregroundStyle(tocVisible ? Color.accentColor : Color.primary)
+                    Image(systemName: hasAnyBookmarkForCurrentFile ? "bookmark.fill" : "bookmark")
+                        .foregroundStyle(hasAnyBookmarkForCurrentFile ? Color.accentColor : Color.primary)
                 }
-                .help("Toggle Outline (⌥⌘0)")
+                .help("Bookmark Current Spot (⌘D)")
+                .disabled(selectedEntry == nil)
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    inspectorVisible.toggle()
+                    if inspectorVisible { bookmarks.refreshFileExistence() }
+                } label: {
+                    Image(systemName: "sidebar.right")
+                        .foregroundStyle(inspectorVisible ? Color.accentColor : Color.primary)
+                }
+                .help("Toggle Inspector (⌥⌘0)")
                 .keyboardShortcut("0", modifiers: [.command, .option])
-                .disabled(tocHeadings.isEmpty)
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openFile)) { _ in
@@ -173,6 +220,15 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .searchHistory)) { _ in
             focusGlobalSearch()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .toggleBookmark)) { _ in
+            addBookmarkAtCurrentSpot()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openBookmarkSlot)) { notif in
+            if let n = notif.object as? Int { openBookmarkSlot(n) }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .togglePlaceholder)) { _ in
+            togglePlaceholder()
+        }
         .onOpenURL { url in
             loadFile(url)
         }
@@ -184,6 +240,21 @@ struct ContentView: View {
         }
         .onChange(of: rawMarkdown) { _ in
             if isSearching { recomputeMatches() }
+            // Visible-block tracking is per-document; reset so the topmost-visible
+            // calculation doesn't use indices from the previous file before its
+            // blocks finish disappearing.
+            visibleBlocks.removeAll()
+            // If we got here via jumpTo() with a pending anchor, resolve it now
+            // that the new document's blocks exist.
+            if let anchor = pendingPostLoadAnchor {
+                let resolved = resolveBookmarkAnchor(
+                    blocks: blocks,
+                    storedIndex: anchor.blockIndex,
+                    fingerprint: anchor.fingerprint
+                )
+                pendingPostLoadAnchor = nil
+                pendingAnchorBlock = resolved
+            }
         }
         .onChange(of: isSearching) { active in
             if active {
@@ -586,12 +657,37 @@ struct ContentView: View {
                                     .padding(.vertical, 2)
                                     .background(
                                         RoundedRectangle(cornerRadius: 4)
-                                            .fill(highlightColor(forBlock: idx))
+                                            .fill(blockBackground(forBlock: idx))
                                             .animation(.easeOut(duration: 0.18), value: currentMatchIndex)
                                             .animation(.easeOut(duration: 0.18), value: matches)
                                             .animation(.easeOut(duration: 0.18), value: isSearching)
+                                            .animation(.easeOut(duration: 0.12), value: hoveredBlock)
                                     )
+                                    .overlay(alignment: .leading) {
+                                        // Accent stripe along the left edge of the hovered block —
+                                        // this is the "you will bookmark here" affordance, since a
+                                        // read-only viewer has no insertion caret.
+                                        if hoveredBlock == idx && highlightColor(forBlock: idx) == .clear {
+                                            Rectangle()
+                                                .fill(Color.accentColor)
+                                                .frame(width: 2)
+                                                .padding(.vertical, 1)
+                                                .transition(.opacity)
+                                        }
+                                    }
                                     .id("block-\(idx)")
+                                    .onAppear { visibleBlocks.insert(idx) }
+                                    .onDisappear {
+                                        visibleBlocks.remove(idx)
+                                        if hoveredBlock == idx { hoveredBlock = nil }
+                                    }
+                                    .onHover { inside in
+                                        if inside {
+                                            hoveredBlock = idx
+                                        } else if hoveredBlock == idx {
+                                            hoveredBlock = nil
+                                        }
+                                    }
                             }
                         }
                         .textSelection(.enabled)
@@ -609,6 +705,17 @@ struct ContentView: View {
                         }
                         DispatchQueue.main.async {
                             tocScrollTrigger = nil
+                        }
+                    }
+                    .onChange(of: pendingAnchorBlock) { newValue in
+                        guard let target = newValue else { return }
+                        // The blocks may not all be laid out yet on first paint —
+                        // give SwiftUI a tick before scrolling.
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                            withAnimation(.easeOut(duration: 0.25)) {
+                                proxy.scrollTo("block-\(target)", anchor: .top)
+                            }
+                            pendingAnchorBlock = nil
                         }
                     }
                 }
@@ -680,7 +787,67 @@ struct ContentView: View {
         return out.trimmingCharacters(in: .whitespaces)
     }
 
-    private var tocSidebar: some View {
+    // MARK: - Right inspector (TOC + Bookmarks)
+
+    private var inspectorPanel: some View {
+        GeometryReader { geo in
+            VStack(spacing: 0) {
+                tocPane
+                    .frame(maxHeight: .infinity)
+
+                if bookmarksExpandedRaw {
+                    inspectorDivider(totalHeight: geo.size.height)
+                }
+
+                bookmarksHeader
+
+                if bookmarksExpandedRaw {
+                    bookmarksContent
+                        .frame(height: clampedBookmarksHeight(total: geo.size.height))
+                }
+            }
+        }
+        .background(VisualEffectView(material: .sidebar, blendingMode: .behindWindow))
+    }
+
+    private func clampedBookmarksHeight(total: CGFloat) -> CGFloat {
+        let header: CGFloat = 32
+        let minToc: CGFloat = 80
+        let minBookmarks: CGFloat = 120
+        let maxBookmarks = max(minBookmarks, total - minToc - header - 8)
+        return min(max(CGFloat(bookmarksHeight), minBookmarks), maxBookmarks)
+    }
+
+    private func inspectorDivider(totalHeight: CGFloat) -> some View {
+        ZStack {
+            // 12pt-tall transparent hit-target so the divider is comfortably grabbable.
+            // The visible 1pt rule is centered inside it.
+            Color.clear
+                .frame(height: 12)
+                .contentShape(Rectangle())
+            Rectangle()
+                .fill(bookmarksDividerHovered ? Color.accentColor.opacity(0.5) : Color.black.opacity(0.08))
+                .frame(height: bookmarksDividerHovered ? 2 : 1)
+                .animation(.easeInOut(duration: 0.15), value: bookmarksDividerHovered)
+        }
+        .onHover { inside in
+            bookmarksDividerHovered = inside
+            if inside { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    let header: CGFloat = 32
+                    let minToc: CGFloat = 80
+                    let minBookmarks: CGFloat = 120
+                    let maxBookmarks = max(minBookmarks, totalHeight - minToc - header - 8)
+                    let proposed = CGFloat(bookmarksHeight) - value.translation.height
+                    bookmarksHeight = Double(min(max(proposed, minBookmarks), maxBookmarks))
+                }
+        )
+    }
+
+    private var tocPane: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 Text("On this page")
@@ -718,7 +885,253 @@ struct ContentView: View {
                 }
             }
         }
-        .background(VisualEffectView(material: .sidebar, blendingMode: .behindWindow))
+    }
+
+    // MARK: - Bookmarks pane
+
+    private var bookmarksHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: bookmarksExpandedRaw ? "chevron.down" : "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .frame(width: 10)
+            Text("Bookmarks")
+                .font(.system(size: 11, weight: .semibold))
+                .textCase(.uppercase)
+                .tracking(0.6)
+                .foregroundStyle(.tertiary)
+            Spacer()
+            if !bookmarks.bookmarks.isEmpty {
+                Text("\(bookmarks.bookmarks.count)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(
+                        Capsule().fill(Color.primary.opacity(0.06))
+                    )
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(height: 32)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeOut(duration: 0.18)) {
+                bookmarksExpandedRaw.toggle()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var bookmarksContent: some View {
+        if bookmarks.bookmarks.isEmpty && placeholder == nil {
+            VStack(spacing: 8) {
+                Spacer(minLength: 8)
+                Image(systemName: "bookmark")
+                    .font(.system(size: 22, weight: .light))
+                    .foregroundStyle(.tertiary)
+                Text("No bookmarks")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 4) {
+                    Text("Press").font(.system(size: 10)).foregroundStyle(.tertiary)
+                    keyCap("⌘"); keyCap("D")
+                    Text("at a spot in any file").font(.system(size: 10)).foregroundStyle(.tertiary)
+                }
+                Spacer(minLength: 8)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            bookmarksList
+        }
+    }
+
+    private var bookmarksList: some View {
+        // ScrollView + LazyVStack instead of List because SwiftUI List on macOS
+        // doesn't fire .onMove from a plain mouse drag without an explicit drag
+        // handle in the row. Hand-rolled .onDrag/.onDrop gives us mouse-drag
+        // reordering with a row-shaped drag preview, which is what the user
+        // expects when they grab a bookmark to push it into a hotkey slot.
+        ScrollView {
+            LazyVStack(spacing: 1) {
+                if let p = placeholder {
+                    placeholderRow(p)
+                        .padding(.bottom, 2)
+                    Divider()
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                }
+
+                ForEach(bookmarks.bookmarks) { bookmark in
+                    bookmarkRow(bookmark)
+                        .contextMenu {
+                            Button("Go to Bookmark") { loadBookmark(bookmark) }
+                                .disabled(!bookmark.fileExists)
+                            Button("Reveal in Finder") {
+                                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: bookmark.path)])
+                            }
+                            .disabled(!bookmark.fileExists)
+                            Divider()
+                            Button(role: .destructive) {
+                                bookmarks.remove(id: bookmark.id)
+                            } label: {
+                                Text("Remove Bookmark")
+                            }
+                        }
+                        .onDrag {
+                            draggingBookmarkID = bookmark.id
+                            return NSItemProvider(object: "mdv-bookmark:\(bookmark.id)" as NSString)
+                        }
+                        .onDrop(
+                            of: [.text],
+                            delegate: BookmarkDropDelegate(
+                                target: bookmark,
+                                manager: bookmarks,
+                                hovered: $dropTargetBookmarkID,
+                                dragging: $draggingBookmarkID
+                            )
+                        )
+                }
+                Color.clear
+                    .frame(height: 24)
+                    .onDrop(
+                        of: [.text],
+                        delegate: BookmarkDropTailDelegate(
+                            manager: bookmarks,
+                            dragging: $draggingBookmarkID
+                        )
+                    )
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func placeholderRow(_ p: PlaceholderAnchor) -> some View {
+        let missing = !FileManager.default.fileExists(atPath: p.path)
+        return Button {
+            togglePlaceholder()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(missing ? Color.orange : Color.accentColor)
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(p.title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(missing ? Color.secondary : Color.primary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(URL(fileURLWithPath: p.path).lastPathComponent)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 4)
+                hotkeyBadge(0, onAccent: false)
+            }
+            .opacity(missing ? 0.6 : 1.0)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(hoveredPlaceholder ? Color.primary.opacity(0.06) : Color.accentColor.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(Color.accentColor.opacity(0.25), lineWidth: 0.5)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { inside in
+            hoveredPlaceholder = inside
+        }
+        .help("Placeholder (⌘0): swap back here")
+        .contextMenu {
+            Button("Clear Placeholder") { placeholder = nil }
+        }
+    }
+
+    private func bookmarkRow(_ bookmark: Bookmark) -> some View {
+        let slot = bookmarks.slotIndex(for: bookmark.id)
+        let missing = !bookmark.fileExists
+        let hovered = hoveredBookmark == bookmark.id
+        let dragging = draggingBookmarkID == bookmark.id
+        let dropHover = dropTargetBookmarkID == bookmark.id
+        let filename = URL(fileURLWithPath: bookmark.path).lastPathComponent
+
+        return Button {
+            loadBookmark(bookmark)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: missing ? "exclamationmark.triangle.fill" : "bookmark.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(missing ? Color.orange : Color.accentColor.opacity(0.7))
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(bookmark.title.isEmpty ? "(unnamed)" : bookmark.title)
+                        .font(.system(size: 13))
+                        .foregroundStyle(missing ? Color.secondary : Color.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text(filename)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 4)
+                if let n = slot {
+                    hotkeyBadge(n, onAccent: false)
+                }
+            }
+            .opacity(missing ? 0.6 : (dragging ? 0.4 : 1.0))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(
+                        dropHover ? Color.accentColor.opacity(0.18) :
+                        (hovered ? Color.primary.opacity(0.06) : Color.clear)
+                    )
+            )
+            .overlay(alignment: .top) {
+                if dropHover {
+                    Rectangle()
+                        .fill(Color.accentColor)
+                        .frame(height: 2)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { inside in
+            hoveredBookmark = inside ? bookmark.id : nil
+        }
+    }
+
+    private func hotkeyBadge(_ n: Int, onAccent: Bool) -> some View {
+        HStack(spacing: 0) {
+            Text("⌘")
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+            Text("\(n)")
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .monospacedDigit()
+        }
+        .foregroundStyle(onAccent ? Color.accentColor : Color.white)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(onAccent ? Color.white : Color.accentColor.opacity(0.85))
+        )
     }
 
     private func tocRow(_ heading: TOCHeading) -> some View {
@@ -876,6 +1289,15 @@ struct ContentView: View {
         return .clear
     }
 
+    /// Background fill for a markdown block. Find highlights win over hover so
+    /// search-in-progress feedback isn't drowned out by mouse position.
+    private func blockBackground(forBlock idx: Int) -> Color {
+        let find = highlightColor(forBlock: idx)
+        if find != .clear { return find }
+        if hoveredBlock == idx { return Color.accentColor.opacity(0.07) }
+        return .clear
+    }
+
     private func scrollToCurrentMatch(proxy: ScrollViewProxy) {
         guard matches.indices.contains(currentMatchIndex) else { return }
         let match = matches[currentMatchIndex]
@@ -960,6 +1382,7 @@ struct ContentView: View {
     private func spawnNewWindow(with url: URL) {
         let view = ContentView(initialURL: url)
             .environmentObject(history)
+            .environmentObject(bookmarks)
             .frame(minWidth: 760, minHeight: 520)
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
@@ -976,6 +1399,152 @@ struct ContentView: View {
         guard FileManager.default.isReadableFile(atPath: url.path) else { return }
         let entry = history.add(path: url.path)
         selectedEntry = entry
+    }
+
+    // MARK: - Bookmarks
+
+    private var hasAnyBookmarkForCurrentFile: Bool {
+        guard let path = selectedEntry?.path else { return false }
+        return bookmarks.hasAnyBookmark(forPath: path)
+    }
+
+    /// Index of the topmost block currently visible in the markdown viewport.
+    /// Falls back to 0 if nothing has reported visible yet.
+    private var topVisibleBlock: Int {
+        visibleBlocks.min() ?? 0
+    }
+
+    /// Compute a human-readable title for a block: nearest preceding ATX heading
+    /// if there is one within reach, else the block's own first 40 chars.
+    private func bookmarkTitle(forBlockAt index: Int) -> String {
+        let docBlocks = self.blocks
+        guard !docBlocks.isEmpty else { return "(empty)" }
+        let clamped = max(0, min(index, docBlocks.count - 1))
+        // Walk backwards looking for a heading. Cap the search so we don't
+        // mislabel a deep-in-the-doc bookmark with a very distant section header.
+        let lookback = 40
+        for i in stride(from: clamped, through: max(0, clamped - lookback), by: -1) {
+            let block = docBlocks[i].trimmingCharacters(in: .whitespacesAndNewlines)
+            if block.hasPrefix("```") { continue }
+            let prefix: String?
+            if block.hasPrefix("### ") { prefix = "### " }
+            else if block.hasPrefix("## ") { prefix = "## " }
+            else if block.hasPrefix("# ") { prefix = "# " }
+            else { prefix = nil }
+            if let pfx = prefix {
+                let firstLine = block.components(separatedBy: "\n").first ?? block
+                return stripInlineMarkdown(String(firstLine.dropFirst(pfx.count)))
+            }
+        }
+        // No heading nearby; use the block's own first content line as a label.
+        let block = docBlocks[clamped]
+        let firstLine = block.components(separatedBy: "\n").first ?? block
+        let cleaned = stripInlineMarkdown(firstLine).trimmingCharacters(in: .whitespaces)
+        if cleaned.isEmpty { return "(line \(clamped + 1))" }
+        return String(cleaned.prefix(60))
+    }
+
+    private func currentAnchorTitle() -> String {
+        bookmarkTitle(forBlockAt: topVisibleBlock)
+    }
+
+    private func currentBlockFingerprint() -> String {
+        let docBlocks = self.blocks
+        let idx = max(0, min(topVisibleBlock, docBlocks.count - 1))
+        guard idx < docBlocks.count else { return "" }
+        return bookmarkFingerprint(forBlock: docBlocks[idx])
+    }
+
+    private func addBookmarkAtCurrentSpot() {
+        guard let entry = selectedEntry else { return }
+        // Prefer whatever block the user is currently pointing at. The hover
+        // highlight is the "you'll bookmark here" indicator; if no block is
+        // hovered (e.g. user pressed ⌘D from a non-mouse path), fall back to
+        // the topmost-visible block.
+        let block = hoveredBlock ?? topVisibleBlock
+        let docBlocks = blocks
+        let fp = (block < docBlocks.count) ? bookmarkFingerprint(forBlock: docBlocks[block]) : ""
+        _ = bookmarks.add(
+            path: entry.path,
+            title: bookmarkTitle(forBlockAt: block),
+            blockIndex: block,
+            fingerprint: fp
+        )
+        if bookmarks.bookmarks.count == 1 {
+            withAnimation(.easeOut(duration: 0.22)) {
+                bookmarksExpandedRaw = true
+                inspectorVisible = true
+            }
+        }
+    }
+
+    /// Jump to a bookmark's anchor. If the file is already loaded, just scroll.
+    /// Otherwise reload the file and scroll once it lands.
+    private func loadBookmark(_ bookmark: Bookmark) {
+        if !bookmark.fileExists {
+            bookmarks.refreshFileExistence()
+            guard FileManager.default.fileExists(atPath: bookmark.path) else {
+                NSSound.beep()
+                return
+            }
+        }
+        jumpTo(
+            path: bookmark.path,
+            blockIndex: bookmark.blockIndex,
+            fingerprint: bookmark.blockFingerprint
+        )
+    }
+
+    private func openBookmarkSlot(_ n: Int) {
+        guard let bookmark = bookmarks.bookmark(forSlot: n) else {
+            NSSound.beep()
+            return
+        }
+        loadBookmark(bookmark)
+    }
+
+    /// Common path for navigating to (path, anchor) — used by saved bookmarks
+    /// and by the ⌘0 placeholder. If `path` matches the currently-loaded file
+    /// we skip the reload and just scroll.
+    private func jumpTo(path: String, blockIndex: Int, fingerprint: String) {
+        let url = URL(fileURLWithPath: path)
+        if selectedEntry?.path == path && !rawMarkdown.isEmpty {
+            // Same file; resolve the anchor against the current document and scroll.
+            let resolved = resolveBookmarkAnchor(
+                blocks: blocks,
+                storedIndex: blockIndex,
+                fingerprint: fingerprint
+            )
+            pendingAnchorBlock = resolved
+        } else {
+            // Different file. Stash the anchor; loadFile will trigger a
+            // rawMarkdown change, after which we resolve and scroll.
+            pendingPostLoadAnchor = (blockIndex, fingerprint)
+            loadFile(url)
+        }
+    }
+
+    /// ⌘0: flip between current spot and the placeholder.
+    /// - First press (no placeholder set): captures current as placeholder.
+    /// - Subsequent press: jumps to placeholder while saving current as the new placeholder,
+    ///   so a second ⌘0 brings you back. Pure two-position toggle.
+    private func togglePlaceholder() {
+        guard let entry = selectedEntry else { return }
+        let block = hoveredBlock ?? topVisibleBlock
+        let docBlocks = blocks
+        let fp = (block < docBlocks.count) ? bookmarkFingerprint(forBlock: docBlocks[block]) : ""
+        let current = PlaceholderAnchor(
+            path: entry.path,
+            title: bookmarkTitle(forBlockAt: block),
+            blockIndex: block,
+            blockFingerprint: fp
+        )
+        if let prev = placeholder {
+            placeholder = current
+            jumpTo(path: prev.path, blockIndex: prev.blockIndex, fingerprint: prev.blockFingerprint)
+        } else {
+            placeholder = current
+        }
     }
 
     private func loadCurrentEntry() {
@@ -1000,6 +1569,78 @@ struct ContentView: View {
             guard ["md", "markdown", "txt", "mdown", "mkd"].contains(ext) else { return }
             DispatchQueue.main.async {
                 loadFile(url)
+            }
+        }
+        return true
+    }
+}
+
+// MARK: - Bookmark drag-drop
+
+/// Handles drops onto a specific bookmark row — the dragged bookmark is moved
+/// to that target row's index. Tail drops (past the last row) are handled by
+/// `BookmarkDropTailDelegate` because a row delegate can't see "below the list."
+private struct BookmarkDropDelegate: DropDelegate {
+    let target: Bookmark
+    let manager: BookmarksManager
+    @Binding var hovered: Int64?
+    @Binding var dragging: Int64?
+
+    func validateDrop(info: DropInfo) -> Bool { true }
+
+    func dropEntered(info: DropInfo) {
+        // Don't show a drop indicator on the row being dragged (no-op move).
+        if let dragging, dragging == target.id {
+            hovered = nil
+        } else {
+            hovered = target.id
+        }
+    }
+
+    func dropExited(info: DropInfo) {
+        if hovered == target.id { hovered = nil }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        defer {
+            hovered = nil
+            dragging = nil
+        }
+        guard let provider = info.itemProviders(for: [.text]).first else { return false }
+        let mgr = manager
+        let targetID = target.id
+        provider.loadObject(ofClass: NSString.self) { item, _ in
+            guard let str = item as? String else { return }
+            // Payload format: "mdv-bookmark:<id>"
+            let parts = str.components(separatedBy: ":")
+            guard parts.count == 2, parts[0] == "mdv-bookmark", let id = Int64(parts[1]) else { return }
+            DispatchQueue.main.async {
+                guard let dest = mgr.bookmarks.firstIndex(where: { $0.id == targetID }) else { return }
+                mgr.moveBookmark(id: id, toIndex: dest)
+            }
+        }
+        return true
+    }
+}
+
+/// Drop target for the spacer below the last bookmark — sends the dragged item
+/// to the very end of the list.
+private struct BookmarkDropTailDelegate: DropDelegate {
+    let manager: BookmarksManager
+    @Binding var dragging: Int64?
+
+    func validateDrop(info: DropInfo) -> Bool { true }
+
+    func performDrop(info: DropInfo) -> Bool {
+        defer { dragging = nil }
+        guard let provider = info.itemProviders(for: [.text]).first else { return false }
+        let mgr = manager
+        provider.loadObject(ofClass: NSString.self) { item, _ in
+            guard let str = item as? String else { return }
+            let parts = str.components(separatedBy: ":")
+            guard parts.count == 2, parts[0] == "mdv-bookmark", let id = Int64(parts[1]) else { return }
+            DispatchQueue.main.async {
+                mgr.moveBookmarkToEnd(id: id)
             }
         }
         return true

--- a/mdv/Database.swift
+++ b/mdv/Database.swift
@@ -23,6 +23,19 @@ final class Database {
         let snippet: String
     }
 
+    struct BookmarkRow: Equatable {
+        let id: Int64
+        let path: String
+        let title: String
+        let sortOrder: Int
+        let createdAt: Date
+        /// Index of the block that was at the top of the viewport when bookmarked.
+        let blockIndex: Int
+        /// First ~80 characters of that block, normalized. Lets us re-locate the
+        /// anchor after the file has been edited and block indices have shifted.
+        let blockFingerprint: String
+    }
+
     private init() {
         let url = Database.databaseURL
         try? FileManager.default.createDirectory(
@@ -101,7 +114,149 @@ final class Database {
             VALUES (new.id, new.filename, new.content, new.path);
         END;
         """)
-        exec("INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '1');")
+        // Bookmarks. Multiple bookmarks per file allowed (markdown docs can be
+        // huge; bookmarks are the in-doc navigation primitive). Each row carries
+        // the block index it was anchored at PLUS a fingerprint of that block's
+        // first ~80 chars — when the file is edited and indices shift, we re-
+        // locate the anchor by fingerprint match.
+        exec("""
+        CREATE TABLE IF NOT EXISTS bookmarks (
+            id                INTEGER PRIMARY KEY,
+            path              TEXT NOT NULL,
+            title             TEXT NOT NULL,
+            sort_order        INTEGER NOT NULL,
+            created_at        INTEGER NOT NULL,
+            block_index       INTEGER NOT NULL DEFAULT 0,
+            block_fingerprint TEXT NOT NULL DEFAULT ''
+        );
+        """)
+        exec("CREATE INDEX IF NOT EXISTS bookmarks_sort ON bookmarks(sort_order);")
+
+        // Migration v1→v2: an earlier dev build of this branch shipped a
+        // schema with `path UNIQUE` and no anchor columns. If we find that
+        // shape, drop and recreate. (Real users on main never had bookmarks,
+        // so there's nothing to preserve.)
+        if scalarString(sql: "SELECT value FROM meta WHERE key = 'schema_version';") != "2" {
+            exec("DROP TABLE IF EXISTS bookmarks;")
+            exec("""
+            CREATE TABLE bookmarks (
+                id                INTEGER PRIMARY KEY,
+                path              TEXT NOT NULL,
+                title             TEXT NOT NULL,
+                sort_order        INTEGER NOT NULL,
+                created_at        INTEGER NOT NULL,
+                block_index       INTEGER NOT NULL DEFAULT 0,
+                block_fingerprint TEXT NOT NULL DEFAULT ''
+            );
+            """)
+            exec("CREATE INDEX IF NOT EXISTS bookmarks_sort ON bookmarks(sort_order);")
+            exec("INSERT INTO meta(key, value) VALUES ('schema_version', '2') ON CONFLICT(key) DO UPDATE SET value = '2';")
+        }
+    }
+
+    private func scalarString(sql: String) -> String? {
+        guard let db = db else { return nil }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        if sqlite3_step(stmt) == SQLITE_ROW, let cstr = sqlite3_column_text(stmt, 0) {
+            return String(cString: cstr)
+        }
+        return nil
+    }
+
+    // MARK: - Bookmarks
+    //
+    // Bookmark UI runs synchronously off the main thread because the dataset is
+    // tiny (capped by user attention, not file count) and writes are fan-in:
+    // toggle / reorder / delete. Reads happen during view updates and need to
+    // return on the calling thread to avoid a redraw round-trip.
+
+    func loadBookmarks() -> [BookmarkRow] {
+        guard let db = db else { return [] }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db,
+            "SELECT id, path, title, sort_order, created_at, block_index, block_fingerprint FROM bookmarks ORDER BY sort_order, created_at;",
+            -1, &stmt, nil) == SQLITE_OK else { return [] }
+
+        var rows: [BookmarkRow] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let id    = sqlite3_column_int64(stmt, 0)
+            let path  = String(cString: sqlite3_column_text(stmt, 1))
+            let title = String(cString: sqlite3_column_text(stmt, 2))
+            let order = Int(sqlite3_column_int64(stmt, 3))
+            let created = TimeInterval(sqlite3_column_int64(stmt, 4))
+            let blockIdx = Int(sqlite3_column_int64(stmt, 5))
+            let fp = sqlite3_column_text(stmt, 6).map { String(cString: $0) } ?? ""
+            rows.append(BookmarkRow(
+                id: id, path: path, title: title,
+                sortOrder: order,
+                createdAt: Date(timeIntervalSince1970: created),
+                blockIndex: blockIdx,
+                blockFingerprint: fp
+            ))
+        }
+        return rows
+    }
+
+    @discardableResult
+    func addBookmark(
+        path: String,
+        title: String,
+        sortOrder: Int,
+        blockIndex: Int,
+        blockFingerprint: String
+    ) -> BookmarkRow? {
+        guard let db = db else { return nil }
+        let now = Int64(Date().timeIntervalSince1970)
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        let sql = """
+        INSERT INTO bookmarks (path, title, sort_order, created_at, block_index, block_fingerprint)
+        VALUES (?, ?, ?, ?, ?, ?);
+        """
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, title, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int64(stmt, 3, Int64(sortOrder))
+        sqlite3_bind_int64(stmt, 4, now)
+        sqlite3_bind_int64(stmt, 5, Int64(blockIndex))
+        sqlite3_bind_text(stmt, 6, blockFingerprint, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else { return nil }
+        let id = sqlite3_last_insert_rowid(db)
+        return BookmarkRow(
+            id: id, path: path, title: title,
+            sortOrder: sortOrder,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(now)),
+            blockIndex: blockIndex,
+            blockFingerprint: blockFingerprint
+        )
+    }
+
+    func removeBookmark(id: Int64) {
+        guard let db = db else { return }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_prepare_v2(db, "DELETE FROM bookmarks WHERE id = ?;", -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_int64(stmt, 1, id)
+            _ = sqlite3_step(stmt)
+        }
+    }
+
+    func setBookmarkOrder(idsInOrder ids: [Int64]) {
+        guard let db = db else { return }
+        sqlite3_exec(db, "BEGIN;", nil, nil, nil)
+        for (idx, id) in ids.enumerated() {
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, "UPDATE bookmarks SET sort_order = ? WHERE id = ?;", -1, &stmt, nil) == SQLITE_OK {
+                sqlite3_bind_int64(stmt, 1, Int64(idx))
+                sqlite3_bind_int64(stmt, 2, id)
+                _ = sqlite3_step(stmt)
+            }
+            sqlite3_finalize(stmt)
+        }
+        sqlite3_exec(db, "COMMIT;", nil, nil, nil)
     }
 
     // MARK: - Indexing

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -44,8 +44,13 @@ struct mdvApp: App {
                 }
                 .keyboardShortcut("d", modifiers: .command)
 
-                Button("Flip to Placeholder") {
-                    NotificationCenter.default.post(name: .togglePlaceholder, object: nil)
+                Button("Set Placeholder") {
+                    NotificationCenter.default.post(name: .setPlaceholder, object: nil)
+                }
+                .keyboardShortcut("0", modifiers: [.command, .shift])
+
+                Button("Jump to Placeholder") {
+                    NotificationCenter.default.post(name: .jumpToPlaceholder, object: nil)
                 }
                 .keyboardShortcut("0", modifiers: .command)
 
@@ -94,5 +99,6 @@ extension Notification.Name {
     static let searchHistory = Notification.Name("searchHistory")
     static let toggleBookmark = Notification.Name("toggleBookmark")
     static let openBookmarkSlot = Notification.Name("openBookmarkSlot")
-    static let togglePlaceholder = Notification.Name("togglePlaceholder")
+    static let setPlaceholder = Notification.Name("setPlaceholder")
+    static let jumpToPlaceholder = Notification.Name("jumpToPlaceholder")
 }

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -4,12 +4,14 @@ import AppKit
 @main
 struct mdvApp: App {
     @StateObject private var history = HistoryManager()
+    @StateObject private var bookmarks = BookmarksManager()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
         Window("mdv", id: "main") {
             ContentView()
                 .environmentObject(history)
+                .environmentObject(bookmarks)
                 .frame(minWidth: 760, minHeight: 520)
         }
         .defaultSize(width: 1080, height: 720)
@@ -36,7 +38,36 @@ struct mdvApp: App {
                 }
                 .keyboardShortcut("f", modifiers: [.command, .shift])
             }
+            CommandMenu("Bookmarks") {
+                Button("Bookmark Current Spot") {
+                    NotificationCenter.default.post(name: .toggleBookmark, object: nil)
+                }
+                .keyboardShortcut("d", modifiers: .command)
+
+                Button("Flip to Placeholder") {
+                    NotificationCenter.default.post(name: .togglePlaceholder, object: nil)
+                }
+                .keyboardShortcut("0", modifiers: .command)
+
+                Divider()
+
+                ForEach(1...BookmarksManager.maxSlots, id: \.self) { n in
+                    let bookmark = bookmarks.bookmark(forSlot: n)
+                    Button(bookmarkSlotLabel(n: n, bookmark: bookmark)) {
+                        NotificationCenter.default.post(name: .openBookmarkSlot, object: n)
+                    }
+                    .keyboardShortcut(KeyEquivalent(Character("\(n)")), modifiers: .command)
+                    .disabled(bookmark == nil)
+                }
+            }
         }
+    }
+
+    private func bookmarkSlotLabel(n: Int, bookmark: Bookmark?) -> String {
+        if let b = bookmark {
+            return "\(n).  \(b.title)"
+        }
+        return "Slot \(n) — Empty"
     }
 }
 
@@ -61,4 +92,7 @@ extension Notification.Name {
     static let openURLInWindow = Notification.Name("openURLInWindow")
     static let findInDocument = Notification.Name("findInDocument")
     static let searchHistory = Notification.Name("searchHistory")
+    static let toggleBookmark = Notification.Name("toggleBookmark")
+    static let openBookmarkSlot = Notification.Name("openBookmarkSlot")
+    static let togglePlaceholder = Notification.Name("togglePlaceholder")
 }


### PR DESCRIPTION
## Summary

Adds a Bookmarks panel to the right inspector (below the existing TOC, separated by a draggable horizontal divider). Bookmarks anchor to a specific block in the document — markdown docs can be huge and bookmarks are the in-doc navigation primitive.

## Behavior

- **Anchored to position**, not just file: each bookmark stores block_index + an 80-char fingerprint of the block's content. The fingerprint matches first; the index is the fallback so anchors survive small file edits.
- **Multiple bookmarks per file** — the file's nearest preceding heading becomes the bookmark title.
- **⌘1–⌘5** load the first five bookmarks. Drag-reorder is the way to assign hotkey slots.
- **⌘0 placeholder** — a transient in-memory swap-back slot. First press captures current spot; subsequent press flips between placeholder and current. Not persisted in SQLite — it's per-session navigation state. Renders as a pin-icon row above the saved bookmarks with an accent-tinted background.
- **Hover-to-anchor**: since a viewer has no caret, hovering over a markdown block paints a subtle accent tint and a left-edge accent stripe. ⌘D anchors to the hovered block (falls back to topmost-visible).
- **Missing files** stay in the list but render dimmed with an orange triangle icon; ⌘N for a missing file beeps. File existence re-checks on inspector open.
- **Drag-drop reorder** uses NSItemProvider with explicit DropDelegates because SwiftUI List's .onMove doesn't fire from a plain mouse drag on macOS without an explicit drag handle.

## Schema

Bumped to v2: drops UNIQUE on bookmarks.path (multiple per file allowed) and adds block_index + block_fingerprint columns. Existing dev-shape tables get dropped and recreated; main has never had bookmarks data, so nothing to migrate.

## Test plan

- [ ] make builds clean
- [ ] ⌘D on a fresh file with no bookmarks: inspector slides open, bookmarks section auto-expands, row appears with the heading title and ⌘1 badge
- [ ] Hover over different blocks: left-edge accent stripe + tint follow the cursor; ⌘D anchors to whichever block is hovered
- [ ] ⌘1–⌘5 load saved bookmarks (intra-file scrolls; cross-file loads + scrolls)
- [ ] ⌘0 with no placeholder: captures current spot. Scroll elsewhere → ⌘0 jumps back. ⌘0 again jumps forward
- [ ] Drag a bookmark above another: positions swap, hotkey badges update
- [ ] Delete a bookmarked file from disk, toggle inspector: row turns dim with orange triangle. ⌘N for that bookmark beeps and no-ops
- [ ] Right-click on missing-file row: Go to / Reveal disabled, Remove enabled
- [ ] Drag the divider between TOC and Bookmarks: bookmarks pane resizes within clamp bounds
- [ ] ⌥⌘0 toggles inspector visibility
- [ ] Schema migration: previous-shape bookmarks table gets recreated with new columns; meta.schema_version advances to 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)