### PR TITLE
GitHub Actions CI + auto-published "latest" prerelease

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,121 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Cancel any older run for the same ref so the queue doesn't pile up
+# while you're force-pushing fixups to a PR.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (${{ matrix.config }})
+    runs-on: macos-15
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [debug, release]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          xcode-select -p
+          xcodebuild -version
+          swift --version
+
+      # SwiftPM checkout cache. The .build/checkouts/ directory holds the
+      # cloned dependencies (swift-markdown-ui, SwiftTreeSitter, swift-cmark,
+      # NetworkImage, tree-sitter); caching it shaves the second build down
+      # to compile-only.
+      - name: Cache SwiftPM checkouts
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ matrix.config }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-${{ matrix.config }}-
+            ${{ runner.os }}-spm-
+
+      - name: Build ${{ matrix.config }}
+        run: ./build.sh ${{ matrix.config }}
+
+      # Sanity-check that the assembled bundle has everything the app
+      # needs at runtime — Info.plist, the executable, fonts, tree-
+      # sitter highlight queries, AppIcon — and that codesign didn't
+      # error out.
+      - name: Verify .app bundle
+        run: |
+          set -euo pipefail
+          APP="build/mdv.app"
+          test -d "$APP" || { echo "✗ no $APP"; exit 1; }
+          test -x "$APP/Contents/MacOS/mdv" || { echo "✗ executable missing"; exit 1; }
+          test -f "$APP/Contents/Info.plist" || { echo "✗ Info.plist missing"; exit 1; }
+          test -f "$APP/Contents/Resources/AppIcon.icns" || { echo "✗ AppIcon missing"; exit 1; }
+
+          ls "$APP/Contents/Resources/" | grep -q "Alegreya-Regular.otf" \
+            || { echo "✗ bundled fonts missing"; exit 1; }
+          ls "$APP/Contents/Resources/" | grep -q "rust-highlights.scm" \
+            || { echo "✗ tree-sitter grammars missing"; exit 1; }
+
+          file "$APP/Contents/MacOS/mdv"
+          codesign -dv "$APP" 2>&1
+          echo "✓ bundle looks healthy"
+
+      # Tar so symlinks / permissions / .app dir structure survive upload.
+      - name: Package artifact
+        if: matrix.config == 'release'
+        run: tar -czf mdv-release.tar.gz -C build mdv.app
+
+      - name: Upload release artifact
+        if: matrix.config == 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdv-release-${{ github.sha }}
+          path: mdv-release.tar.gz
+          retention-days: 14
+
+  # Republishes the release-config build as the "latest" prerelease on every
+  # main-push, giving consumers a stable URL:
+  #   https://github.com/<owner>/<repo>/releases/download/latest/mdv-release.tar.gz
+  # Skipped on PRs (would noisy the releases page and PRs can't write to the
+  # repo's release stream anyway). Runs on Linux because we just need to
+  # download the artifact and call the GitHub API — no macOS toolchain
+  # required for that.
+  publish-latest:
+    name: publish "latest" prerelease
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mdv-release-${{ github.sha }}
+          path: .
+
+      - name: Update "latest" prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest main build
+          prerelease: true
+          files: mdv-release.tar.gz
+          body: |
+            Auto-built from `main` @ ${{ github.sha }} on ${{ github.event.head_commit.timestamp }}.
+
+            ```sh
+            curl -L -o mdv.tar.gz https://github.com/${{ github.repository }}/releases/download/latest/mdv-release.tar.gz
+            tar -xzf mdv.tar.gz && mv mdv.app /Applications/
+            ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ of an evening while yelling at people about zoning reform.
 
 Type `make`.
 
+Or, if you don't feel like compiling: grab the [latest CI build](../../releases/tag/latest), `tar -xzf mdv-release.tar.gz`, drag `mdv.app` to `/Applications/`. CI rebuilds it on every push to `main`, so the link is stable.
+
 ## Here Are My Prompts, Roughly
 
 > Install this macOS UI skill I found.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the app on every push and pull request, plus a follow-on job that republishes a stable `latest` prerelease on every main-push so users can grab a built `mdv.app` without having to compile.

Already validated end-to-end on my fork (`jvanderberg/mdv`) — both PR-trigger and main-push flows passed, and the `latest` release is live there.

## Workflow

- **`build` job** — `macos-15` runner (Xcode 16 / Swift 6 preinstalled)
  - Matrix builds **debug** and **release** so optimizer-only issues surface
  - SwiftPM checkout cache keyed on `Package.resolved` (cold ~1m20s, warm faster)
  - Verifies the assembled `.app` has Info.plist, executable, AppIcon, bundled fonts, and tree-sitter highlight queries — guards against `build.sh` copy regressions
  - Uploads a per-commit `mdv-release.tar.gz` artifact (14-day retention)
  - `cancel-in-progress` concurrency group so the second of two quick pushes on the same PR cancels the first

- **`publish-latest` job** — runs only on push to `main` (skipped on PRs)
  - Downloads the release artifact and updates a `latest`-tagged prerelease via `softprops/action-gh-release@v2`, force-overwriting its assets
  - Stable URL on every push: `.../releases/download/latest/mdv-release.tar.gz`

## README

Adds one line under "Installing" pointing at the `latest` release, in the same casual tone as the rest of the README. Uses `../../releases/tag/latest` so the relative link resolves correctly when the README is rendered inside `blob/main/`.

## Notes

- `publish-latest` needs `contents: write` on `GITHUB_TOKEN`. The job declares this via `permissions:`; no repo-settings change is needed unless the org-level default token permissions are restricted to read-only.
- Annotations about Node 20 deprecation appear (current `actions/checkout`, `actions/cache`, `actions/upload-artifact` still ship Node 20). Their Node 24 builds will land before the September 2026 cutoff and we can bump pin then.

## Test plan

- [ ] Push triggers `build (debug)` and `build (release)` jobs, both pass
- [ ] PR opens trigger the same matrix
- [ ] `mdv-release-<sha>` artifact downloadable from the run page
- [ ] On main push, `publish-latest` updates `https://github.com/<repo>/releases/tag/latest` with `mdv-release.tar.gz`
- [ ] README link `[latest CI build](../../releases/tag/latest)` resolves to the release page (not 404)
