### PR TITLE
Add CLI installer, in-app help, and System-appearance theme

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,16 @@ cp mdv/AppIcon.icns             "$APP/Contents/Resources/AppIcon.icns"
 cp mdv/Fonts/*.otf              "$APP/Contents/Resources/"
 cp mdv/Grammars/*-highlights.scm "$APP/Contents/Resources/"
 
+# Bundle the CLI helper so the app can install /usr/local/bin/mdv pointing
+# at this script — the in-app "Install Command Line Tool…" menu symlinks
+# to this path.
+cp bin/mdv                       "$APP/Contents/Resources/mdv"
+chmod +x                         "$APP/Contents/Resources/mdv"
+
+# Bundle the in-app help doc; HelpManager copies it out to a stable path
+# under ~/Library/Application Support/mdv on demand so bookmarks survive.
+cp mdv/Help.md                   "$APP/Contents/Resources/Help.md"
+
 echo "→ codesigning (adhoc)"
 codesign --force --sign - --entitlements mdv/mdv.entitlements "$APP"
 

--- a/mdv/CLIInstaller.swift
+++ b/mdv/CLIInstaller.swift
@@ -1,0 +1,112 @@
+import Foundation
+import AppKit
+
+// Installs /usr/local/bin/mdv as a symlink to the CLI helper bundled inside
+// this .app (Contents/Resources/mdv). Mirrors what `make install-cli` does
+// from the command line, but driven from a menu item so a downloaded .app
+// can wire up the shell command without the user touching the Makefile.
+//
+// /usr/local/bin is root-owned on a stock macOS, so we try a plain symlink
+// first (works on Homebrew-managed prefixes where the user owns the dir)
+// and fall back to NSAppleScript's `with administrator privileges`, which
+// pops the standard auth dialog. The app is unsandboxed (see
+// mdv.entitlements), so this path is permitted.
+enum CLIInstaller {
+    static let destination = "/usr/local/bin/mdv"
+
+    static func install() {
+        guard let source = bundledScriptPath() else {
+            alert(title: "CLI helper missing",
+                  message: "The bundled mdv script wasn't found inside this build.",
+                  style: .warning)
+            return
+        }
+
+        if let resolved = try? FileManager.default.destinationOfSymbolicLink(atPath: destination),
+           resolved == source {
+            alert(title: "Already installed",
+                  message: "\(destination) already points to this app.",
+                  style: .informational)
+            return
+        }
+
+        if symlinkUnprivileged(source: source, destination: destination) {
+            reportSuccess(source: source)
+            return
+        }
+
+        switch symlinkWithAdminAuth(source: source, destination: destination) {
+        case .success:
+            reportSuccess(source: source)
+        case .cancelled:
+            break
+        case .failed(let message):
+            alert(title: "Install failed", message: message, style: .warning)
+        }
+    }
+
+    private static func bundledScriptPath() -> String? {
+        Bundle.main.url(forResource: "mdv", withExtension: nil)?.path
+    }
+
+    private static func symlinkUnprivileged(source: String, destination: String) -> Bool {
+        let fm = FileManager.default
+        let parent = (destination as NSString).deletingLastPathComponent
+        do {
+            if !fm.fileExists(atPath: parent) {
+                try fm.createDirectory(atPath: parent, withIntermediateDirectories: true)
+            }
+            // removeItem covers regular files and existing symlinks (including dangling ones).
+            if fm.fileExists(atPath: destination)
+                || (try? fm.destinationOfSymbolicLink(atPath: destination)) != nil {
+                try fm.removeItem(atPath: destination)
+            }
+            try fm.createSymbolicLink(atPath: destination, withDestinationPath: source)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private enum AuthResult {
+        case success
+        case cancelled
+        case failed(String)
+    }
+
+    private static func symlinkWithAdminAuth(source: String, destination: String) -> AuthResult {
+        let parent = (destination as NSString).deletingLastPathComponent
+        let shell = "/bin/mkdir -p \(shellQuote(parent)) && /bin/ln -sf \(shellQuote(source)) \(shellQuote(destination))"
+        // Embed the shell string inside an AppleScript string literal — escape
+        // backslashes first, then double-quotes, in that order.
+        let escaped = shell
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let appleScript = "do shell script \"\(escaped)\" with administrator privileges"
+
+        var errInfo: NSDictionary?
+        NSAppleScript(source: appleScript)?.executeAndReturnError(&errInfo)
+        guard let err = errInfo else { return .success }
+        // -128 is the AppleScript "user cancelled" code from the auth dialog.
+        if (err[NSAppleScript.errorNumber] as? Int) == -128 { return .cancelled }
+        return .failed((err[NSAppleScript.errorMessage] as? String) ?? "Unknown error")
+    }
+
+    private static func shellQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func reportSuccess(source: String) {
+        alert(title: "Command line tool installed",
+              message: "\(destination) → \(source)\n\nYou can now run `mdv` from your terminal.",
+              style: .informational)
+    }
+
+    private static func alert(title: String, message: String, style: NSAlert.Style) {
+        let a = NSAlert()
+        a.messageText = title
+        a.informativeText = message
+        a.alertStyle = style
+        a.runModal()
+    }
+}

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -779,11 +779,21 @@ struct ContentView: View {
     /// active one. Selection persists via ThemeManager (@AppStorage).
     private var themeMenu: some View {
         Menu {
+            Button {
+                themes.setSelection(ThemeManager.systemID)
+            } label: {
+                if themes.selectedID == ThemeManager.systemID {
+                    Label(ThemeManager.systemDisplayName, systemImage: "checkmark")
+                } else {
+                    Text(ThemeManager.systemDisplayName)
+                }
+            }
+            Divider()
             ForEach(MDVTheme.all) { theme in
                 Button {
                     themes.set(theme)
                 } label: {
-                    if themes.current.id == theme.id {
+                    if themes.selectedID == theme.id {
                         Label(theme.name, systemImage: "checkmark")
                     } else {
                         Text(theme.name)
@@ -796,7 +806,14 @@ struct ContentView: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
-        .help("Theme: \(themes.current.name)")
+        .help(themeMenuHelpText)
+    }
+
+    private var themeMenuHelpText: String {
+        if themes.selectedID == ThemeManager.systemID {
+            return "Theme: System — \(themes.current.name)"
+        }
+        return "Theme: \(themes.current.name)"
     }
 
     // MARK: - External editor
@@ -2060,6 +2077,7 @@ struct ContentView: View {
         let view = ContentView(initialURL: url)
             .environmentObject(history)
             .environmentObject(bookmarks)
+            .environmentObject(themes)
             .frame(minWidth: 760, minHeight: 520)
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)

--- a/mdv/Help.md
+++ b/mdv/Help.md
@@ -1,0 +1,48 @@
+# mdv help
+
+A "totally solved problem in computer science" rendered into a window. Here is what it does and how to make it do it.
+
+## Opening files
+
+- **⌘O** opens a file. **⌘⇧O** opens one in a new window.
+- Drop a `.md` (or `.markdown`, or `.mdown`) onto the icon — works.
+- Drop a *directory* onto the icon — picks `README.md` if it finds one, otherwise the alphabetically-first markdown, and seeds the rest into history as siblings.
+- Run `mdv FILE` from the terminal once you have installed the CLI. Hit **mdv → Install Command Line Tool…** to drop the symlink into `/usr/local/bin`. Yes, it asks for your password. No, it is not phoning home.
+
+## Moving around
+
+- **⌘←** / **⌘→** — back and forward through files you have recently opened. Like a browser. The thing browsers do.
+- Click a link to a sibling `.md` in the same directory — it loads. Click an `https://` link — it goes to your browser, where it belongs.
+- `#fragment` links scroll to the matching heading. `[See above](#earlier-section)` actually does that.
+
+## Find
+
+- **⌘F** — find in the current document. The inline kind, with highlights and a counter, like every text app shipped after 1998.
+- **⌘⇧F** — search across every file in your history. This is **TEXT SEARCH TECHNOLOGY**, which other Markdown viewers on the App Store somehow do not ship. Patent pending.
+
+## Bookmarks
+
+Every program eventually evolves bookmarks. We did not fight it.
+
+- **⌘D** — bookmark the spot you are looking at.
+- **⌘1**..**⌘5** — jump to bookmark slots 1 through 5.
+- **⌘⇧0** — drop a transient placeholder at the current spot. **⌘0** — jump back to it. The placeholder lives in memory only; restart the app and it is gone. That is a feature.
+- This help file lives at `~/Library/Application Support/mdv/Help.md`, which means you can bookmark sections of it like anything else. Welcome to the meta-help.
+
+## Sidebars
+
+- **TOC** — h1/h2/h3 headings, click to jump. Toggle from the toolbar.
+- **History** — every file you have opened, ever, until you swipe one left and tap delete. Survives restart.
+
+## Themes
+
+A frustrated, untalented graphic designer (the author) could not resist letting two LLMs argue with him about typography. The result is several themes. Pick one from the toolbar. Do not @ me about font choices.
+
+## Editor integration
+
+- **⌘E** — open the current file in your external editor.
+- **File → Edit → Choose Editor…** — pick which editor. **Forget Editor** clears it.
+
+## When things go sideways
+
+If links do not go where you expect, fragments do not scroll, or the CLI complains it cannot find `mdv.app`: file an issue. Or yell at the author about zoning reform. Either works.

--- a/mdv/HelpManager.swift
+++ b/mdv/HelpManager.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// Materializes the bundled Help.md to a stable path under
+// ~/Library/Application Support/mdv/ before opening it as a regular
+// markdown document. Going through a stable path (instead of opening the
+// bundle resource directly) keeps bookmarks valid across .app moves and
+// reinstalls — bookmarks are keyed by absolute path, and the bundle's
+// own path changes whenever you drag mdv.app to a new location.
+//
+// We rewrite the user-facing copy each time Help is opened so doc updates
+// in newer builds flow through without needing the user to delete the
+// stale file.
+enum HelpManager {
+    static func openHelp() -> URL? {
+        guard let bundled = Bundle.main.url(forResource: "Help", withExtension: "md") else {
+            return nil
+        }
+        let dest = userHelpURL()
+        do {
+            try FileManager.default.createDirectory(
+                at: dest.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            // Always overwrite — keeps the content in sync with the running build.
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try FileManager.default.removeItem(at: dest)
+            }
+            try FileManager.default.copyItem(at: bundled, to: dest)
+        } catch {
+            return nil
+        }
+        return dest
+    }
+
+    private static func userHelpURL() -> URL {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first!
+        return appSupport
+            .appendingPathComponent("mdv", isDirectory: true)
+            .appendingPathComponent("Help.md")
+    }
+}

--- a/mdv/ThemeManager.swift
+++ b/mdv/ThemeManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import MarkdownUI
 
@@ -751,20 +752,69 @@ extension MDVTheme {
 
 /// Owns the user's current theme choice. Backed by `@AppStorage` so the
 /// last-selected theme persists across launches without any explicit save.
+///
+/// `selectedID` is what the user picked, which may be the special
+/// `systemID` sentinel meaning "follow the macOS appearance"; `current`
+/// is always a concrete theme. When the user is on `systemID` we KVO
+/// `NSApp.effectiveAppearance` so a system Light↔Dark switch reflows the
+/// document immediately.
 final class ThemeManager: ObservableObject {
+    /// Sentinel selection meaning "follow the system appearance". Resolves
+    /// to High Contrast in light mode, Twilight in dark.
+    static let systemID = "system"
+
+    /// Display name for the synthetic System entry in the theme picker.
+    static let systemDisplayName = "System"
+
     @AppStorage("mdv_theme_id") private var storedID: String = MDVTheme.default.id
 
+    /// What the user picked — may be `systemID`. Use this for menu
+    /// checkmarks; use `current` for actual rendering.
+    @Published private(set) var selectedID: String = MDVTheme.default.id
     @Published var current: MDVTheme = .default
 
+    private var appearanceObservation: NSKeyValueObservation?
+
     init() {
-        // Pull initial value from @AppStorage. The property wrapper isn't
-        // observable for our @Published mirror, so we sync once at init and
-        // again on every set(_:).
-        self.current = MDVTheme.byID(storedID)
+        self.selectedID = storedID
+        self.current = Self.resolve(id: storedID)
+        // KVO on effectiveAppearance: the OS posts when the user toggles
+        // dark mode, when scheduled night-shift fires, or when the
+        // appearance is forced on a per-window basis. We only re-resolve
+        // when the user's selection is "system" — explicit picks are sticky.
+        appearanceObservation = NSApp.observe(\.effectiveAppearance, options: [.new]) { [weak self] _, _ in
+            guard let self else { return }
+            DispatchQueue.main.async { self.systemAppearanceChanged() }
+        }
     }
 
+    /// Pick a concrete theme. Use `setSelection(_:)` with `systemID` for
+    /// the follow-the-system option.
     func set(_ theme: MDVTheme) {
-        current = theme
-        storedID = theme.id
+        setSelection(theme.id)
+    }
+
+    func setSelection(_ id: String) {
+        selectedID = id
+        storedID = id
+        current = Self.resolve(id: id)
+    }
+
+    private func systemAppearanceChanged() {
+        guard selectedID == Self.systemID else { return }
+        let resolved = Self.resolve(id: Self.systemID)
+        if resolved.id != current.id { current = resolved }
+    }
+
+    private static func resolve(id: String) -> MDVTheme {
+        if id == systemID {
+            return systemIsDark() ? .twilight : .highContrast
+        }
+        return MDVTheme.byID(id)
+    }
+
+    private static func systemIsDark() -> Bool {
+        let match = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+        return match == .darkAqua
     }
 }

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -27,6 +27,12 @@ struct mdvApp: App {
         .defaultSize(width: 1080, height: 720)
         .windowToolbarStyle(.unified(showsTitle: true))
         .commands {
+            CommandGroup(after: .appInfo) {
+                Divider()
+                Button("Install Command Line Tool…") {
+                    CLIInstaller.install()
+                }
+            }
             CommandGroup(replacing: .newItem) {
                 Button("Open…") {
                     NotificationCenter.default.post(name: .openFile, object: nil)
@@ -70,6 +76,18 @@ struct mdvApp: App {
                     NotificationCenter.default.post(name: .navigateForward, object: nil)
                 }
                 .keyboardShortcut(.rightArrow, modifiers: .command)
+            }
+            CommandGroup(replacing: .help) {
+                Button("mdv Help") {
+                    if let url = HelpManager.openHelp() {
+                        NotificationCenter.default.post(name: .openURLInWindow, object: url)
+                        if let win = NSApp.keyWindow ?? NSApp.windows.first {
+                            win.makeKeyAndOrderFront(nil)
+                        }
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                }
+                .keyboardShortcut("?", modifiers: .command)
             }
             CommandMenu("Bookmarks") {
                 Button("Bookmark Current Spot") {


### PR DESCRIPTION
## Summary

- **Install Command Line Tool…** under the `mdv` menu symlinks `/usr/local/bin/mdv` to a copy of `bin/mdv` bundled at `Contents/Resources/mdv`. Plain symlink first; falls back to `NSAppleScript` with admin privileges for the auth dialog. Mirrors what `make install-cli` does.
- **mdv Help** under the Help menu (⌘?) opens a bundled, snarky `Help.md` as a regular markdown doc. The bundled file is materialized to `~/Library/Application Support/mdv/Help.md` so bookmarks survive across .app moves and reinstalls.
- **System** entry in the theme picker follows `NSApp.effectiveAppearance` — High Contrast in light, Twilight in dark — and re-resolves live via KVO when the system appearance flips.
- Fixes a crash on **⌘⇧O** (Open in New Window): `spawnNewWindow` was injecting `history` and `bookmarks` env objects but not `themes`, while ContentView declares all three.

## Test plan

- [ ] `./build.sh debug` and `./build.sh release` build clean.
- [ ] Launch the built app, hit **mdv → Install Command Line Tool…** — auth prompt appears, `/usr/local/bin/mdv` ends up symlinked to the bundled script, `mdv --version` works in the terminal.
- [ ] **Help → mdv Help** (⌘?) opens the help doc; bookmark a section with ⌘D, restart, bookmark survives.
- [ ] Toolbar paintpalette → **System** — tracks Light↔Dark when toggled in Control Center, no relaunch needed.
- [ ] **⌘⇧O** opens a new window without crashing, theme renders correctly.