### PR TITLE
Remember per-file scroll position across launches

### DIFF
--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -102,6 +102,21 @@ struct ContentView: View {
     /// new document's blocks are computed. We can't resolve the fingerprint
     /// against the document until rawMarkdown updates.
     @State private var pendingPostLoadAnchor: (blockIndex: Int, fingerprint: String)? = nil
+    /// Mirror of `selectedEntry` updated *after* `loadCurrentEntry` runs, so
+    /// we always know which file is currently in `rawMarkdown` independently
+    /// of `selectedEntry` (which flips synchronously when a sidebar click /
+    /// link / bookmark jump fires, before `loadCurrentEntry` mutates
+    /// `rawMarkdown`). Used by the cross-doc onChange handler to identify
+    /// the file being left so we can persist its scroll position before
+    /// `rawMarkdown` flips to the new file.
+    @State private var lastLoadedEntry: HistoryEntry? = nil
+    /// Set by `loadCurrentEntry` immediately before it mutates `rawMarkdown`.
+    /// The `.onChange(of: rawMarkdown)` handler consumes this to decide
+    /// whether to restore a saved scroll position. Gating on this flag means
+    /// FileWatcher-driven reloads (the user is reading and the file gets
+    /// rewritten by an external editor) do NOT snap the viewport back —
+    /// FileWatcher mutates rawMarkdown directly, bypassing `loadCurrentEntry`.
+    @State private var pendingScrollRestore: Bool = false
 
     /// In-memory placeholder slot (⌘0). Holds "the spot I want to flip back to."
     /// Not persisted — pure per-window navigation state, like Vim's last-jump
@@ -316,6 +331,16 @@ struct ContentView: View {
             handleDrop(providers)
         }
         .onChange(of: selectedEntry) { _ in
+            // Persist the leaving file's scroll position FIRST, before we touch
+            // `rawMarkdown` via `loadCurrentEntry`. We deliberately use
+            // `lastLoadedEntry` (mirror updated *after* loadCurrentEntry on
+            // prior ticks) instead of `previousSelectedEntry` (which is
+            // managed by the back-stack handler on `body` and whose
+            // observation order vs. this handler isn't guaranteed). At this
+            // point `rawMarkdown` and `blocks` still reflect that file.
+            if let leaving = lastLoadedEntry, leaving.path != selectedEntry?.path {
+                persistScrollPosition(for: leaving)
+            }
             // Selection changed by something other than a bookmark/placeholder
             // jump? Then drop the "active bookmark" highlight.
             if !bookmarkNavInProgress {
@@ -324,15 +349,31 @@ struct ContentView: View {
             }
             bookmarkNavInProgress = false
             loadCurrentEntry()
+            lastLoadedEntry = selectedEntry
         }
         .onChange(of: rawMarkdown) { _ in
             if isSearching { recomputeMatches() }
-            // Visible-block tracking is per-document; reset so the topmost-visible
-            // calculation doesn't use indices from the previous file before its
-            // blocks finish disappearing.
-            visibleBlocks.removeAll()
-            // If we got here via jumpTo() with a pending anchor, resolve it now
-            // that the new document's blocks exist.
+            // Visible-block tracking carries indices from the leaving doc.
+            // We can't just `removeAll()`: SwiftUI's `ForEach(id: \.offset)`
+            // keeps blocks with the same offset mounted across a doc swap,
+            // so their `.onAppear` does NOT refire on the new doc — wiping
+            // the set leaves it permanently empty for indices that share
+            // identity with the old doc, and `topVisibleBlock` collapses
+            // to 0 even when the user is reading mid-document. Instead,
+            // drop only the indices that don't exist in the new doc; the
+            // surviving entries correctly reflect blocks still on screen
+            // (because their views were never unmounted), and SwiftUI's
+            // `.onAppear` / `.onDisappear` will manage the rest as the
+            // user scrolls.
+            visibleBlocks = visibleBlocks.filter { $0 < blocks.count }
+            // Anchor precedence on a new document load:
+            //   1. bookmark / placeholder jump (pendingPostLoadAnchor)
+            //   2. fragment link click (pendingFragment)
+            //   3. saved scroll position from a previous visit
+            // Bookmarks set pendingAnchorBlock; fragments scroll asynchronously
+            // via tocScrollTrigger. Either claims the spot — only restore the
+            // saved scroll position if neither did.
+            var anchorClaimed = false
             if let anchor = pendingPostLoadAnchor {
                 let resolved = resolveBookmarkAnchor(
                     blocks: blocks,
@@ -341,12 +382,58 @@ struct ContentView: View {
                 )
                 pendingPostLoadAnchor = nil
                 pendingAnchorBlock = resolved
+                anchorClaimed = true
             }
             // Cross-document fragment scroll, deferred until headings exist.
             if let frag = pendingFragment {
                 pendingFragment = nil
                 // One runloop tick so tocHeadings is up-to-date for the new content.
                 DispatchQueue.main.async { scrollToFragment(frag) }
+                anchorClaimed = true
+            }
+            // Restore the scroll position on every fresh-from-disk load
+            // (`pendingScrollRestore` is set by `loadCurrentEntry`).
+            // FileWatcher reloads mutate rawMarkdown directly without
+            // setting the flag, so external edits don't yank the viewport
+            // back to where the user last left off.
+            //
+            // Always end up setting `pendingAnchorBlock` to *something*,
+            // even on a never-visited file or an invalidated anchor —
+            // ScrollView retains its offset across doc swaps, so leaving
+            // `pendingAnchorBlock` nil leaves the user wherever the
+            // previous doc was scrolled to. Defaulting to 0 (top of doc)
+            // makes the landing deterministic.
+            let shouldRestoreScroll = pendingScrollRestore && !anchorClaimed
+            pendingScrollRestore = false
+            if shouldRestoreScroll, let entry = selectedEntry {
+                var landingBlock = 0
+                if let saved = Database.shared.loadScrollPosition(path: entry.path),
+                   saved.blockIndex > 0 {
+                    // Two safety nets before honoring the saved anchor:
+                    //   1. mtime — markdown files change behind our back
+                    //      (user edits in another app, git checkout,
+                    //      etc.). If the file's mtime differs from what
+                    //      we recorded, treat the anchor as stale and
+                    //      fall back to the top rather than dropping the
+                    //      user into possibly-shifted content. The
+                    //      fingerprint handles *small* edits; mtime is
+                    //      the bigger hammer.
+                    //   2. bounds — if the recorded index is past the
+                    //      end of the (now shorter) document, fall back
+                    //      to the top explicitly rather than silently
+                    //      clamping to the last block.
+                    let currentMtime = (try? FileManager.default.attributesOfItem(atPath: entry.path)[.modificationDate] as? Date)??.timeIntervalSince1970
+                    let mtimeMatches = currentMtime.map { abs($0 - saved.fileMtime) < 1.0 } ?? false
+                    let inBounds = saved.blockIndex < blocks.count
+                    if mtimeMatches && inBounds {
+                        landingBlock = resolveBookmarkAnchor(
+                            blocks: blocks,
+                            storedIndex: saved.blockIndex,
+                            fingerprint: saved.blockFingerprint
+                        )
+                    }
+                }
+                pendingAnchorBlock = landingBlock
             }
         }
         .onChange(of: isSearching) { active in
@@ -364,9 +451,15 @@ struct ContentView: View {
             } else if let last = history.entries.first {
                 selectedEntry = last
                 loadCurrentEntry()
+                lastLoadedEntry = last
             }
         }
         .onDisappear {
+            // Window close / app quit: persist the current file's scroll
+            // position so the next launch lands on the same spot.
+            if let entry = selectedEntry {
+                persistScrollPosition(for: entry)
+            }
             paneTracker.uninstall()
         }
         .onChange(of: sidebarWidth) { newValue in
@@ -2415,6 +2508,12 @@ struct ContentView: View {
             return
         }
         let url = URL(fileURLWithPath: entry.path)
+        // Mark the upcoming `rawMarkdown` change as a fresh load so the
+        // rawMarkdown onChange handler will restore the saved scroll
+        // anchor for this file (if any). FileWatcher takes a different
+        // path that doesn't set this flag — its reloads should leave
+        // the viewport where it is.
+        pendingScrollRestore = true
         if let content = try? String(contentsOf: url, encoding: .utf8) {
             rawMarkdown = content
         } else {
@@ -2432,6 +2531,40 @@ struct ContentView: View {
                 self.rawMarkdown = fresh
             }
         }
+    }
+
+    /// Persist the current scroll anchor for `entry`. Reads `topVisibleBlock`
+    /// directly (== `visibleBlocks.min()`) rather than the `currentTopBlock`
+    /// mirror, because the back-stack handler on `body` resets
+    /// `currentTopBlock = 0` in its defer block, and SwiftUI's invocation
+    /// order across multiple onChange handlers for the same key isn't
+    /// guaranteed — empirically that defer can fire before this save runs.
+    /// `visibleBlocks` is safe to read here: it's only wiped by the
+    /// `.onChange(of: rawMarkdown)` handler, which fires on the *next*
+    /// runloop tick after `loadCurrentEntry` mutates `rawMarkdown`, well
+    /// after we've already saved.
+    ///
+    /// Caller must invoke this BEFORE any code path that mutates `rawMarkdown`
+    /// for a different file — otherwise `blocks` will already reflect the
+    /// new file and the fingerprint will be wrong.
+    private func persistScrollPosition(for entry: HistoryEntry) {
+        let docBlocks = blocks
+        let idx = topVisibleBlock
+        let fp = (idx >= 0 && idx < docBlocks.count)
+            ? bookmarkFingerprint(forBlock: docBlocks[idx])
+            : ""
+        // Stamp the file's current mtime alongside the anchor — on restore we
+        // compare to the file's mtime at load time and invalidate the anchor
+        // if the file has changed under us. The fingerprint already gives us
+        // resilience to *small* edits, but a wholesale rewrite could leave the
+        // user dropped into nonsense.
+        let mtime = (try? FileManager.default.attributesOfItem(atPath: entry.path)[.modificationDate] as? Date)??.timeIntervalSince1970 ?? 0
+        Database.shared.saveScrollPosition(
+            path: entry.path,
+            blockIndex: idx,
+            fingerprint: fp,
+            fileMtime: mtime
+        )
     }
 
     private func handleDrop(_ providers: [NSItemProvider]) -> Bool {

--- a/mdv/Database.swift
+++ b/mdv/Database.swift
@@ -36,6 +36,19 @@ final class Database {
         let blockFingerprint: String
     }
 
+    /// "Where the user was last reading inside this file." One row per file, keyed
+    /// on absolute path. The fingerprint scheme survives *small* edits between
+    /// sessions; `fileMtime` is the bigger hammer — when the saved mtime
+    /// differs from the file's current mtime, the caller should treat the
+    /// anchor as stale and fall back to the top of the document rather than
+    /// dropping the user into possibly-shifted content.
+    struct ScrollPosition: Equatable {
+        let blockIndex: Int
+        let blockFingerprint: String
+        /// File mtime (Unix seconds) at the moment this anchor was saved.
+        let fileMtime: TimeInterval
+    }
+
     private init() {
         let url = Database.databaseURL
         try? FileManager.default.createDirectory(
@@ -132,11 +145,31 @@ final class Database {
         """)
         exec("CREATE INDEX IF NOT EXISTS bookmarks_sort ON bookmarks(sort_order);")
 
-        // Migration v1→v2: an earlier dev build of this branch shipped a
-        // schema with `path UNIQUE` and no anchor columns. If we find that
-        // shape, drop and recreate. (Real users on main never had bookmarks,
-        // so there's nothing to preserve.)
-        if scalarString(sql: "SELECT value FROM meta WHERE key = 'schema_version';") != "2" {
+        // Per-file last-viewed scroll anchor. Purely additive in v3; the
+        // CREATE IF NOT EXISTS handles both fresh installs and v2 upgrades.
+        // v4 adds `file_mtime` so we can invalidate the anchor when the
+        // file changes under us — handled below as an ALTER TABLE for
+        // existing v3 rows.
+        exec("""
+        CREATE TABLE IF NOT EXISTS scroll_positions (
+            path              TEXT PRIMARY KEY,
+            block_index       INTEGER NOT NULL,
+            block_fingerprint TEXT NOT NULL,
+            updated_at        INTEGER NOT NULL,
+            file_mtime        INTEGER NOT NULL DEFAULT 0
+        );
+        """)
+
+        // Stepwise migrations off the recorded schema_version. The CREATE IF
+        // NOT EXISTS calls above already have fresh installs in the right
+        // shape; this block only fires for legacy rows that need fixups
+        // beyond what additive DDL covers.
+        let version = Int(scalarString(sql: "SELECT value FROM meta WHERE key = 'schema_version';") ?? "0") ?? 0
+
+        // v1→v2: an earlier dev build of the bookmarks branch shipped a
+        // schema with `path UNIQUE` and no anchor columns. Real users on
+        // main never had it, so we drop+recreate without preserving rows.
+        if version < 2 {
             exec("DROP TABLE IF EXISTS bookmarks;")
             exec("""
             CREATE TABLE bookmarks (
@@ -150,7 +183,21 @@ final class Database {
             );
             """)
             exec("CREATE INDEX IF NOT EXISTS bookmarks_sort ON bookmarks(sort_order);")
-            exec("INSERT INTO meta(key, value) VALUES ('schema_version', '2') ON CONFLICT(key) DO UPDATE SET value = '2';")
+        }
+
+        // v2→v3: scroll_positions added (handled by CREATE IF NOT EXISTS
+        // above — nothing to fix up here, just record the bump).
+
+        // v3→v4: scroll_positions gains `file_mtime`. CREATE IF NOT EXISTS
+        // already includes the column for fresh installs; existing v3 rows
+        // need an ALTER TABLE. SQLite's ALTER TABLE ... ADD COLUMN is cheap
+        // (metadata-only) and supported since 3.x.
+        if version == 3 {
+            exec("ALTER TABLE scroll_positions ADD COLUMN file_mtime INTEGER NOT NULL DEFAULT 0;")
+        }
+
+        if version < 4 {
+            exec("INSERT INTO meta(key, value) VALUES ('schema_version', '4') ON CONFLICT(key) DO UPDATE SET value = '4';")
         }
     }
 
@@ -259,6 +306,65 @@ final class Database {
         sqlite3_exec(db, "COMMIT;", nil, nil, nil)
     }
 
+    // MARK: - Scroll positions
+    //
+    // Same access pattern as bookmarks: tiny payload, fan-in writes, reads
+    // happen during view updates and need to return on the calling thread.
+
+    /// Look up the saved scroll anchor for `path`. Returns nil if the file
+    /// has never been viewed (or was never scrolled past block 0).
+    func loadScrollPosition(path: String) -> ScrollPosition? {
+        guard let db = db else { return nil }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db,
+            "SELECT block_index, block_fingerprint, file_mtime FROM scroll_positions WHERE path = ?;",
+            -1, &stmt, nil) == SQLITE_OK else { return nil }
+        sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        let idx = Int(sqlite3_column_int64(stmt, 0))
+        let fp = sqlite3_column_text(stmt, 1).map { String(cString: $0) } ?? ""
+        let mtime = TimeInterval(sqlite3_column_int64(stmt, 2))
+        return ScrollPosition(blockIndex: idx, blockFingerprint: fp, fileMtime: mtime)
+    }
+
+    /// Persist (or overwrite) the saved scroll anchor for `path`. Stores the
+    /// file's mtime alongside the anchor so a later read can detect a stale
+    /// entry without rehashing content.
+    func saveScrollPosition(path: String, blockIndex: Int, fingerprint: String, fileMtime: TimeInterval) {
+        guard let db = db else { return }
+        let now = Int64(Date().timeIntervalSince1970)
+        let mtimeI = Int64(fileMtime)
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        let sql = """
+        INSERT INTO scroll_positions (path, block_index, block_fingerprint, updated_at, file_mtime)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(path) DO UPDATE SET
+            block_index       = excluded.block_index,
+            block_fingerprint = excluded.block_fingerprint,
+            updated_at        = excluded.updated_at,
+            file_mtime        = excluded.file_mtime;
+        """
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int64(stmt, 2, Int64(blockIndex))
+        sqlite3_bind_text(stmt, 3, fingerprint, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_int64(stmt, 4, now)
+        sqlite3_bind_int64(stmt, 5, mtimeI)
+        _ = sqlite3_step(stmt)
+    }
+
+    func clearScrollPosition(path: String) {
+        guard let db = db else { return }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_prepare_v2(db, "DELETE FROM scroll_positions WHERE path = ?;", -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+            _ = sqlite3_step(stmt)
+        }
+    }
+
     // MARK: - Indexing
 
     /// Index or refresh a file. Skips work if the on-disk mtime matches what we already stored.
@@ -278,11 +384,16 @@ final class Database {
     func removeFile(at path: String) {
         queue.async { [weak self] in
             guard let self, let db = self.db else { return }
-            var stmt: OpaquePointer?
-            defer { sqlite3_finalize(stmt) }
-            if sqlite3_prepare_v2(db, "DELETE FROM articles WHERE path = ?;", -1, &stmt, nil) == SQLITE_OK {
-                sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
-                _ = sqlite3_step(stmt)
+            for sql in [
+                "DELETE FROM articles WHERE path = ?;",
+                "DELETE FROM scroll_positions WHERE path = ?;",
+            ] {
+                var stmt: OpaquePointer?
+                if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                    sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+                    _ = sqlite3_step(stmt)
+                }
+                sqlite3_finalize(stmt)
             }
         }
     }


### PR DESCRIPTION
## Summary

Persist the topmost-visible block per file in the existing SQLite store so reopening a markdown file lands the user where they left off. Same anchor scheme as bookmarks — block index plus a normalized 80-char fingerprint of that block's content — so the position survives small edits.

## How it works

**Save** fires from two places:
- Cross-doc `onChange(of: selectedEntry)`, **before** `loadCurrentEntry` flips `rawMarkdown` — at that moment `blocks` and `visibleBlocks` still reflect the leaving file. Uses a separate `lastLoadedEntry` mirror rather than the back-stack handler's `previousSelectedEntry`, since SwiftUI's invocation order across multiple onChange handlers for the same key isn't guaranteed and the back-stack handler's `defer` resets `currentTopBlock` to 0.
- `onDisappear`, so window close / app quit captures the final spot.

**Restore** fires only on a fresh-from-disk load (new `pendingScrollRestore` flag set by `loadCurrentEntry`; FileWatcher reloads bypass it so external edits don't yank the viewport back). Bookmark / placeholder / fragment anchors still take precedence when set.

**Two safety nets** so a stale anchor can't drop the user into wrong content:
- `file_mtime` is stamped alongside each save. On restore, if the file's mtime no longer matches we fall back to the top of the document instead of honoring the anchor.
- Out-of-bounds index (file shrunk) also falls back to the top.
- "Fall back to top" explicitly sets `pendingAnchorBlock = 0` rather than leaving it nil — `ScrollView` retains its offset across doc swaps, so doing nothing leaves the user wherever the previous file was scrolled.

## Latent bug fixed

The `rawMarkdown` onChange handler used to `visibleBlocks.removeAll()`. Because `ForEach(id: \.offset)` keeps shared-offset blocks mounted across a doc swap, those blocks' `.onAppear` does not refire — so `visibleBlocks` stayed empty for those indices for the rest of the session, collapsing `topVisibleBlock` to 0 even when the user was reading mid-document. Replaced with a filter that drops only indices that don't exist in the new doc; surviving entries correctly reflect blocks still on screen.

## Schema

Bumped to v4. v2→v3 added the `scroll_positions` table; v3→v4 adds `file_mtime` via a metadata-only `ALTER TABLE ADD COLUMN`. `removeFile` cascades to `scroll_positions` so removing a history entry doesn't leak rows.

## Test plan

- [x] Schema migrates v2→v3→v4 cleanly on launch
- [x] Open file, scroll deep, switch to another file, switch back → restored to the same block
- [x] `touch` the file between visits → restore is invalidated, lands at the top
- [x] Out-of-bounds saved index → falls back to top
- [x] FileWatcher reload (external edit) does not snap the viewport
- [x] Bookmark / placeholder / fragment jumps still take precedence over saved scroll
- [x] Tested on multiple machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)