### PR TITLE
Smart typography toggle (curly quotes, em/en-dash, ellipsis)

### DIFF
--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -40,6 +40,11 @@ struct ContentView: View {
     // External editor (Edit button in toolbar)
     @AppStorage("mdv_editor_app_path") private var editorAppPath: String = ""
 
+    /// User preference for SmartyPants-style typography. Default on. The
+    /// effective state is gated by the current theme's
+    /// `smartTypographyAllowed` flag — see `smartTypographyEnabled`.
+    @AppStorage("mdv_smart_typography") private var userSmartTypography: Bool = true
+
     /// Watches the currently-loaded file so external-editor saves push
     /// fresh content into the viewer automatically.
     @State private var fileWatcher = FileWatcher()
@@ -1860,14 +1865,26 @@ struct ContentView: View {
     @ViewBuilder
     private func blockView(block: String, idx: Int) -> some View {
         if shouldInlineHighlight(block: block, idx: idx) {
+            // Find-highlight path: render straight punctuation. Smartening
+            // here would shift character offsets and misalign the yellow
+            // highlight ranges (which were computed against rawMarkdown).
+            // The mismatch only surfaces while find is active in matched
+            // blocks; everything else still gets smart typography.
             Text(highlightedAttributedString(for: block, idx: idx))
                 .frame(maxWidth: .infinity, alignment: .leading)
         } else {
-            Markdown(block)
+            Markdown(smartTypographyEnabled ? smartenMarkdown(block) : block)
                 .markdownTheme(themes.current.markdownTheme)
                 .markdownCodeSyntaxHighlighter(.mdv(theme: themes.current))
                 .markdownImageProvider(LocalImageProvider(baseURL: currentDocumentDirectory))
         }
+    }
+
+    /// Whether to apply SmartyPants-style typography on the next render.
+    /// Honors both the user's preference and the active theme's opt-out
+    /// (Phosphor and Standard Erin Light/Dark force this off).
+    private var smartTypographyEnabled: Bool {
+        userSmartTypography && themes.current.smartTypographyAllowed
     }
 
     /// Directory the currently-loaded markdown file lives in. Relative

--- a/mdv/SmartTypography.swift
+++ b/mdv/SmartTypography.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// Apply SmartyPants-style typography to a chunk of markdown source:
+///
+/// - Straight `"` and `'` curl into directional quotes (`"` `"` `'` `'`),
+///   choosing open vs. close from preceding-character context.
+/// - `---` becomes an em-dash (—). `--` between digits or letters becomes
+///   an en-dash (–). ` -- ` (space-dashdash-space) becomes a spaced em-dash.
+///   Other `--` runs are left alone so CLI flags (`--option`) survive.
+/// - `...` becomes a horizontal ellipsis (…).
+///
+/// Code is not touched: inline backtick spans `` `like this` `` and fenced
+/// code blocks (` ``` ` / `~~~`) are preserved verbatim, including any
+/// quote, dash, or dot characters inside them. Link URLs `](...)` and
+/// autolink / HTML tag spans `<...>` are similarly left as-is.
+///
+/// The function is meant to run on a *single block* of markdown — call
+/// site is `blockView` in ContentView, where blocks are already separated
+/// by the fence-aware splitter. The same backtick-run tracking handles
+/// inline spans within prose blocks.
+func smartenMarkdown(_ source: String) -> String {
+    // Whole-block fenced code: nothing to smarten. Cheap early-exit.
+    let trimmed = source.trimmingCharacters(in: .whitespaces)
+    if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+        return source
+    }
+
+    var result = ""
+    result.reserveCapacity(source.count)
+
+    var i = source.startIndex
+    // Run length of the currently-open inline code span, or 0 if outside.
+    // Markdown inline code closes on a backtick run of *exactly* the same
+    // length as the opener — `` ``foo`` `` has a 2-backtick fence, etc.
+    var codeRun = 0
+    // Inside `](...)` URL portion of a link/image. Track paren depth so a
+    // URL containing `(` like `https://en.wikipedia.org/wiki/Foo_(disambig)`
+    // doesn't close early.
+    var linkParenDepth = 0
+
+    while i < source.endIndex {
+        let c = source[i]
+
+        // ---- Backtick runs (inline code spans) ----
+        if c == "`" {
+            var run = 0
+            var j = i
+            while j < source.endIndex && source[j] == "`" {
+                run += 1
+                j = source.index(after: j)
+            }
+            if codeRun == 0 {
+                codeRun = run
+            } else if codeRun == run {
+                codeRun = 0
+            }
+            // Either way, emit the literal backticks.
+            result.append(String(repeating: "`", count: run))
+            i = j
+            continue
+        }
+
+        if codeRun > 0 {
+            result.append(c)
+            i = source.index(after: i)
+            continue
+        }
+
+        // ---- Link URL: `](...)` ----
+        if linkParenDepth == 0,
+           c == "]",
+           let next = source.index(i, offsetBy: 1, limitedBy: source.endIndex),
+           next < source.endIndex,
+           source[next] == "(" {
+            result.append("](")
+            i = source.index(i, offsetBy: 2)
+            linkParenDepth = 1
+            continue
+        }
+        if linkParenDepth > 0 {
+            result.append(c)
+            if c == "(" { linkParenDepth += 1 }
+            else if c == ")" {
+                linkParenDepth -= 1
+            }
+            i = source.index(after: i)
+            continue
+        }
+
+        // ---- Autolink / HTML tag: `<...>` ----
+        // Only treat as opaque when it really looks like a tag/autolink:
+        // the first char after `<` must be a letter or `/`. That keeps
+        // prose like "x < y" or "<3" working.
+        if c == "<",
+           let inside = source.index(i, offsetBy: 1, limitedBy: source.endIndex),
+           inside < source.endIndex {
+            let firstInside = source[inside]
+            if firstInside.isLetter || firstInside == "/" {
+                // Cap the lookahead so we don't run away on unmatched `<`.
+                let limit = source.index(i, offsetBy: 256, limitedBy: source.endIndex) ?? source.endIndex
+                if let close = source.range(of: ">", range: i..<limit)?.lowerBound {
+                    let endIncl = source.index(after: close)
+                    result.append(contentsOf: source[i..<endIncl])
+                    i = endIncl
+                    continue
+                }
+            }
+        }
+
+        // ---- Em-dash: --- ----
+        if c == "-",
+           let a1 = source.index(i, offsetBy: 1, limitedBy: source.endIndex), a1 < source.endIndex, source[a1] == "-",
+           let a2 = source.index(i, offsetBy: 2, limitedBy: source.endIndex), a2 < source.endIndex, source[a2] == "-" {
+            result.append("\u{2014}")
+            i = source.index(i, offsetBy: 3)
+            continue
+        }
+
+        // ---- En-dash / em-dash: -- ----
+        if c == "-",
+           let a1 = source.index(i, offsetBy: 1, limitedBy: source.endIndex), a1 < source.endIndex, source[a1] == "-" {
+            let prev = (i > source.startIndex) ? source[source.index(before: i)] : nil
+            let next2: Character? = {
+                guard let a2 = source.index(i, offsetBy: 2, limitedBy: source.endIndex), a2 < source.endIndex else { return nil }
+                return source[a2]
+            }()
+
+            let prevDigit = prev?.isNumber ?? false
+            let prevLetter = prev?.isLetter ?? false
+            let prevSpace = prev == " "
+            let nextDigit = next2?.isNumber ?? false
+            let nextLetter = next2?.isLetter ?? false
+            let nextSpace = next2 == " "
+
+            if (prevDigit && nextDigit) || (prevLetter && nextLetter) {
+                // "1989--2026" or "Foo--Bar" — range-style en-dash.
+                result.append("\u{2013}")
+                i = source.index(i, offsetBy: 2)
+                continue
+            }
+            if prevSpace && nextSpace {
+                // "word -- word" — em-dash. Surrounding spaces preserved.
+                result.append("\u{2014}")
+                i = source.index(i, offsetBy: 2)
+                continue
+            }
+            // Anything else (e.g. "--flag" at start, or "x--", "--x") is
+            // left as raw hyphens so CLI examples don't get mangled.
+            result.append("-")
+            i = source.index(after: i)
+            continue
+        }
+
+        // ---- Ellipsis: ... ----
+        if c == ".",
+           let a1 = source.index(i, offsetBy: 1, limitedBy: source.endIndex), a1 < source.endIndex, source[a1] == ".",
+           let a2 = source.index(i, offsetBy: 2, limitedBy: source.endIndex), a2 < source.endIndex, source[a2] == "." {
+            result.append("\u{2026}")
+            i = source.index(i, offsetBy: 3)
+            continue
+        }
+
+        // ---- Quote curling ----
+        if c == "\"" {
+            let prev = (i > source.startIndex) ? source[source.index(before: i)] : nil
+            result.append(isOpenQuoteContext(prev) ? "\u{201C}" : "\u{201D}")
+            i = source.index(after: i)
+            continue
+        }
+        if c == "'" {
+            let prev = (i > source.startIndex) ? source[source.index(before: i)] : nil
+            result.append(isOpenQuoteContext(prev) ? "\u{2018}" : "\u{2019}")
+            i = source.index(after: i)
+            continue
+        }
+
+        result.append(c)
+        i = source.index(after: i)
+    }
+
+    return result
+}
+
+/// True if the character preceding a `"` or `'` puts us in "opening quote"
+/// position. Used by quote curling. The list is the SmartyPants-standard
+/// set of openers (whitespace, start of string, opening brackets, dashes,
+/// ellipsis) plus a few unicode quote cousins so back-to-back constructs
+/// like `…"` or `—"` open correctly.
+private func isOpenQuoteContext(_ prev: Character?) -> Bool {
+    guard let p = prev else { return true }
+    if p.isWhitespace { return true }
+    return "([{<\u{2014}\u{2013}\u{2026}".contains(p)
+}

--- a/mdv/ThemeManager.swift
+++ b/mdv/ThemeManager.swift
@@ -55,6 +55,19 @@ struct MDVTheme: Identifiable, Hashable {
     /// utility/technical themes go wider (Charcoal → 920).
     var articleMaxWidth: CGFloat? = 860
 
+    /// Whether SmartyPants-style typography (curly quotes, em/en-dashes,
+    /// ellipsis) is appropriate for this theme. The user-facing toggle is
+    /// AND-ed with this flag — themes that opt out always render straight
+    /// punctuation, regardless of preference. Default `true`. Themes
+    /// where smart punctuation actively works against the aesthetic or
+    /// the audience override to `false`:
+    /// - Phosphor: amber-on-black CRT homage. Smart quotes break the
+    ///   typewriter / terminal vibe.
+    /// - Standard Erin Light/Dark: dyslexia-friendly themes. Curly
+    ///   quotes and em-dashes are extra glyph variants to disambiguate;
+    ///   we keep punctuation literal and unambiguous.
+    var smartTypographyAllowed: Bool = true
+
     // MARK: Heading scale
 
     /// Heading sizes in em units (relative to body). The MarkdownUI gitHub
@@ -808,6 +821,7 @@ extension MDVTheme {
         blockquoteBar: Color(rgba: 0xFFA500FF),
         sidebarTint: Color(rgba: 0x000000FF),
         sidebarTintOpacity: 0.30,
+        smartTypographyAllowed: false,    // CRT terminals printed straight quotes — curling them breaks the era cue
         accent: Color(rgba: 0xFFA500FF),  // amber — leans into the CRT vibe
         codePalette: .phosphorPalette     // monochrome amber, brightness-only differentiation. No green or red.
     )
@@ -875,6 +889,7 @@ extension MDVTheme {
         baseFontSize: 15,                             // one step under the 16pt default — OpenDyslexic's x-height is large enough that 15pt reads ≈16pt SF; pulls the page back from looking outsized
         // Other typography knobs intentionally left at cross-theme defaults.
         // The font is the theme.
+        smartTypographyAllowed: false,                // dyslexia-friendly: keep punctuation in unambiguous straight forms
         headingFontWeight: .regular,                  // see doc-comment above — OpenDyslexic only ships 400 + 800
         strongFontWeight: .bold,                      // explicit so **emphasis** picks up the 800 variant
         accent: Color(rgba: 0xB0623EFF),              // terracotta
@@ -905,6 +920,7 @@ extension MDVTheme {
         sidebarTintOpacity: 0.32,
         bodyFontFamily: .custom(FontRegistration.dyslexiaBodyFamily),
         baseFontSize: 15,
+        smartTypographyAllowed: false,                // matches light variant — see TYPOGRAPHY.md
         headingFontWeight: .regular,
         strongFontWeight: .bold,
         accent: Color(rgba: 0xC99A4AFF),

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -8,6 +8,12 @@ struct mdvApp: App {
     @StateObject private var themes = ThemeManager()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
+    /// User preference: SmartyPants-style typography on prose. Default on.
+    /// Effective state is `userSmartTypography && themes.current.smartTypographyAllowed`
+    /// — themes whose aesthetic or audience argues against curling
+    /// punctuation (Phosphor, Standard Erin) ignore the preference.
+    @AppStorage("mdv_smart_typography") private var userSmartTypography: Bool = true
+
     init() {
         // Register the bundled Alegreya weights into the process-local font
         // space before any view hierarchy resolves a custom font name. Done
@@ -76,6 +82,24 @@ struct mdvApp: App {
                     NotificationCenter.default.post(name: .navigateForward, object: nil)
                 }
                 .keyboardShortcut(.rightArrow, modifiers: .command)
+            }
+            // View menu addition: Smart Typography toggle. Sits in the
+            // SwiftUI-generated View menu (CommandGroup(after: .toolbar)).
+            // The toggle persists user intent; the *effective* state is
+            // ANDed with the current theme's `smartTypographyAllowed`
+            // flag. When the active theme blocks smart typography we
+            // disable the menu item and append "(off for this theme)"
+            // so the user understands why their preference isn't taking
+            // effect — instead of silently ignoring it.
+            CommandGroup(after: .toolbar) {
+                Divider()
+                Toggle(
+                    themes.current.smartTypographyAllowed
+                        ? "Smart Typography"
+                        : "Smart Typography (off for this theme)",
+                    isOn: $userSmartTypography
+                )
+                .disabled(!themes.current.smartTypographyAllowed)
             }
             CommandGroup(replacing: .help) {
                 Button("mdv Help") {


### PR DESCRIPTION
## Summary

Adds a SmartyPants-style render pass that converts straight ASCII punctuation in prose to its smart equivalents, behind a View → Smart Typography toggle (default on).

## What gets smartened

| Source | Rendered |
| --- | --- |
| \`\"hello\"\` / \`'hello'\` | curly quotes (open vs. close inferred from preceding context) |
| \`---\` | em-dash (—) |
| \`--\` between digits or letters | en-dash (–) for ranges |
| \` -- \` (space-dashdash-space) | spaced em-dash |
| \`...\` | horizontal ellipsis (…) |

## What's left alone

The smartening pass is code- and link-aware. It preserves verbatim:

- Fenced code blocks (the existing fence-aware block splitter already isolates them; the smartener's own backtick-run state handles inline spans)
- Inline backtick spans \`\` `like this` \`\` — matching opener-run length on close
- Link URL portions \`](...)\` — paren-depth tracked so URLs containing \`(\` survive
- Autolink and HTML tag spans \`<...>\` — recognized by \`<letter\` or \`</\`, with a 256-char lookahead so unmatched \`<\` doesn't run away
- CLI flags (\`--option\`, \`--flag\` at start-of-word) — \`--\` only substitutes when the surrounding context says "range" or "interpolation," not "command-line argument"

## Theme awareness

A new \`MDVTheme.smartTypographyAllowed\` knob (default true) gates the user preference. Two themes opt out:

- **Phosphor** — CRT amber-on-black homage. Straight quotes are part of the era cue.
- **Standard Erin Light/Dark** — dyslexia-friendly themes. Keep punctuation in unambiguous straight forms.

User preference and theme allowance are ANDed. On opted-out themes the menu item shows \`Smart Typography (off for this theme)\` and is disabled — better than silently ignoring the click.

## Wiring

- New \`mdv/SmartTypography.swift\` with one public function: \`smartenMarkdown(_ source: String) -> String\`. Walks the source character-by-character with state for backtick runs, link URL paren depth, and angle-bracket spans. ~210 lines.
- \`blockView\` in ContentView calls \`smartenMarkdown(block)\` before passing to MarkdownUI's \`Markdown(...)\` when \`smartTypographyEnabled\` (= user pref AND theme allowance) is true.
- Find / bookmarks / TOC continue to operate on \`rawMarkdown\`, so saved anchors still resolve correctly.
- The inline-find highlight path (\`highlightedAttributedString\`) is intentionally skipped — substitutions would shift character offsets and misalign the yellow highlight ranges. Only matters during active find in matched blocks.
- \`@AppStorage(\"mdv_smart_typography\")\`, default true.
- Menu item is a SwiftUI \`Toggle\` in \`CommandGroup(after: .toolbar)\` so it lands in the auto-generated View menu.

## Test plan

- [x] Quotes, em/en-dashes, ellipsis render smart in prose
- [x] Inline code spans preserve straight punctuation
- [x] Fenced code blocks preserve straight punctuation
- [x] Link URLs preserved (text inside \`[...]\` still smartens)
- [x] Autolinks \`<https://...>\` preserved
- [x] CLI flags (\`--option\`, \`--flag\`) preserved
- [x] Menu toggle persists across launches and switches rendering live
- [x] Phosphor and Standard Erin always render straight regardless of toggle
- [x] Menu shows disabled state with explanation on opted-out themes
- [x] Tested via computer-use against a fixture covering all the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)