### PR TITLE
Open SQLite with SQLITE_OPEN_FULLMUTEX to fix concurrent-connection misuse

### DIFF
--- a/mdv/Database.swift
+++ b/mdv/Database.swift
@@ -55,7 +55,18 @@ final class Database {
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        if sqlite3_open(url.path, &db) != SQLITE_OK {
+        // Open with SQLITE_OPEN_FULLMUTEX so the single shared connection
+        // is internally serialized: macOS ships libsqlite3 in multi-thread
+        // mode (`sqlite3_threadsafe()` returns 2), under which a single
+        // connection may NOT be used concurrently from multiple threads.
+        // We hit that pattern at startup — HistoryManager.init runs
+        // `Database.shared.reindex(...)` on the bg queue while
+        // BookmarksManager.init runs `loadBookmarks()` and the first file
+        // load runs `loadScrollPosition(...)` on main. Without the mutex,
+        // overlapping `sqlite3_step` calls can SIGSEGV in the pager,
+        // return SQLITE_MISUSE silently, or corrupt the DB file.
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        if sqlite3_open_v2(url.path, &db, flags, nil) != SQLITE_OK {
             NSLog("[mdv] failed to open db at %@", url.path)
             db = nil
             return


### PR DESCRIPTION
## Summary

\`Database.shared\` opens one \`sqlite3*\` and steps it from two domains concurrently:

- **Background queue \`com.mdv.app.db\`**: \`reindex\`, \`indexFile\`, \`removeFile\`, \`_search\`
- **Main thread (synchronously)**: \`loadBookmarks\`, \`addBookmark\`, \`removeBookmark\`, \`setBookmarkOrder\`, \`loadScrollPosition\`, \`saveScrollPosition\`, \`clearScrollPosition\`

macOS ships \`libsqlite3\` in multi-thread mode (\`sqlite3_threadsafe() == 2\`). In that mode the library is thread-safe, but a single connection must **not** be used by multiple threads simultaneously.

A concrete startup race: \`HistoryManager.init\` posts \`Database.shared.reindex(paths:)\` to the bg queue at the same tick that \`BookmarksManager.init\` runs \`Database.shared.loadBookmarks()\` on main, and the first file load runs \`Database.shared.loadScrollPosition(...)\` on main. Three threads stepping prepared statements on one \`sqlite3*\`.

Failure modes:
- **SIGSEGV inside SQLite's pager** when prepared-statement state is clobbered mid-\`sqlite3_step\` — the actual crash.
- **SQLITE_MISUSE** return codes (silent — call sites don't check).
- **DB corruption** surfacing later as \`database disk image is malformed\` or stale rows.

The race window is microseconds, so it doesn't fire on every overlap, but the patterns hit on every launch with non-empty history; over enough sessions it'll produce crash reports.

## Fix

Open the connection with \`SQLITE_OPEN_FULLMUTEX\` via \`sqlite3_open_v2\`. That puts the connection in serialized mode — SQLite acquires its own mutex around each API call. One-line change, no behavior shift for callers, overhead is one mutex per call (negligible vs the disk I/O).

The alternative — routing every public method through the existing serial queue — is equivalent but a much larger diff and locks in a synchronous-on-main contract for the bookmark APIs. Open to redoing it that way if preferred.

## Test plan

- [ ] \`./build.sh debug\` and \`./build.sh release\` build clean.
- [ ] App launches, history sidebar populates, bookmarks load, search works.
- [ ] No regression in startup time (mutex is cheap; this should be unmeasurable).