### PR TITLE
View → Zoom (⌘=/⌘−), zoom HUD, native checkmarks in theme menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# mdv
+
+## SwiftUI
+
+Don't write `@State` or `@Published` from a `.onChange(of: X)` when `X` is derived from state the view body writes during layout (e.g. via `onAppear` / `onDisappear`). That creates an infinite re-render loop and pegs the main thread.
+
+If you need the value at navigation/action time, read the computed property directly. If you must mirror it, defer the write with `DispatchQueue.main.async`.
+
+100% CPU with `sample <pid>` showing repeated `GraphHost.flushTransactions` frames is the signature.

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -168,6 +168,12 @@ struct ContentView: View {
         var id: Int { blockIndex }
     }
 
+    // Zoom HUD: shown for ~0.9s whenever themes.fontScale changes,
+    // dismissed via a debounced DispatchWorkItem so repeated ⌘= taps
+    // keep the HUD visible without flicker.
+    @State private var zoomHUDVisible = false
+    @State private var zoomHUDDismiss: DispatchWorkItem?
+
     // Find
     @State private var isSearching = false
     @State private var query = ""
@@ -960,26 +966,21 @@ struct ContentView: View {
     /// active one. Selection persists via ThemeManager (@AppStorage).
     private var themeMenu: some View {
         Menu {
-            Button {
-                themes.setSelection(ThemeManager.systemID)
-            } label: {
-                if themes.selectedID == ThemeManager.systemID {
-                    Label(ThemeManager.systemDisplayName, systemImage: "checkmark")
-                } else {
-                    Text(ThemeManager.systemDisplayName)
-                }
-            }
+            // Toggle inside a Menu renders as a native macOS checked menu
+            // item (system-drawn checkmark, proper indentation for
+            // unselected siblings). The setter ignores `false` because
+            // you don't "uncheck" a theme — picking a different one is
+            // how you switch.
+            Toggle(ThemeManager.systemDisplayName, isOn: Binding(
+                get: { themes.selectedID == ThemeManager.systemID },
+                set: { picked in if picked { themes.setSelection(ThemeManager.systemID) } }
+            ))
             Divider()
             ForEach(MDVTheme.all) { theme in
-                Button {
-                    themes.set(theme)
-                } label: {
-                    if themes.selectedID == theme.id {
-                        Label(theme.name, systemImage: "checkmark")
-                    } else {
-                        Text(theme.name)
-                    }
-                }
+                Toggle(theme.name, isOn: Binding(
+                    get: { themes.selectedID == theme.id },
+                    set: { picked in if picked { themes.set(theme) } }
+                ))
             }
         } label: {
             Image(systemName: "paintpalette")
@@ -1288,7 +1289,48 @@ struct ContentView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
+        .overlay(alignment: .center) {
+            if zoomHUDVisible {
+                zoomHUD
+                    .transition(.opacity.combined(with: .scale(scale: 0.92)))
+            }
+        }
+        .onChange(of: themes.fontScale) { _ in showZoomHUD() }
         .animation(.easeOut(duration: 0.20), value: isSearching)
+        .animation(.easeOut(duration: 0.18), value: zoomHUDVisible)
+    }
+
+    /// macOS volume/brightness-style transient indicator. Centered over
+    /// the content pane, fades in on zoom change, fades out ~0.9s after
+    /// the last change.
+    private var zoomHUD: some View {
+        let pct = Int((themes.fontScale * 100).rounded())
+        return Text("\(pct)%")
+            .font(.system(size: 36, weight: .semibold, design: .rounded))
+            .foregroundStyle(themes.current.text)
+            .monospacedDigit()
+            .padding(.horizontal, 28)
+            .padding(.vertical, 18)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(themes.current.secondaryBackground.opacity(0.92))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(themes.current.border, lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(themes.current.isDark ? 0.45 : 0.18), radius: 14, y: 4)
+            .allowsHitTesting(false)
+    }
+
+    private func showZoomHUD() {
+        zoomHUDVisible = true
+        zoomHUDDismiss?.cancel()
+        let task = DispatchWorkItem {
+            zoomHUDVisible = false
+        }
+        zoomHUDDismiss = task
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: task)
     }
 
     private var blocks: [String] {
@@ -1977,7 +2019,7 @@ struct ContentView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             Markdown(smartTypographyEnabled ? smartenMarkdown(block) : block)
-                .markdownTheme(themes.current.markdownTheme)
+                .markdownTheme(themes.current.markdownTheme(scale: themes.fontScale))
                 .markdownCodeSyntaxHighlighter(.mdv(theme: themes.current))
                 .markdownImageProvider(LocalImageProvider(
                     baseURL: currentDocumentDirectory,

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -90,12 +90,6 @@ struct ContentView: View {
     /// `selectedEntry` so the resulting onChange tick skips the backStack
     /// push. Cleared at the end of that tick.
     @State private var suppressBackStackPush = false
-    /// Mirror of `topVisibleBlock` updated via `.onChange`. Used as the
-    /// "scroll snapshot we're leaving" when pushing onto `backStack`,
-    /// because the computed `topVisibleBlock` reflects whatever's visible
-    /// *now* — by the time we want to capture it on a navigation event,
-    /// `visibleBlocks` may have started churning.
-    @State private var currentTopBlock: Int = 0
     /// If a fragment-bearing link triggers a cross-document load, the
     /// fragment is stashed here and consumed once `rawMarkdown` updates
     /// (the headings only exist after the file is read).
@@ -285,26 +279,22 @@ struct ContentView: View {
             // (goBack/goForward) is in progress, if there's no previous
             // entry (first load), or if the path didn't actually change
             // (history.add creates a fresh entry on every visit — those
-            // re-visits shouldn't clutter the stack). `currentTopBlock`
+            // re-visits shouldn't clutter the stack). `topVisibleBlock`
             // here still reflects the doc we're leaving because the new
-            // doc's blocks haven't fired their onAppear yet.
-            let leavingTop = currentTopBlock
+            // doc's blocks haven't fired their onAppear yet — read the
+            // computed property directly rather than mirroring it via
+            // another .onChange (writing state from a render-driven
+            // onChange triggers infinite re-render in SwiftUI).
+            let leavingTop = topVisibleBlock
             defer {
                 suppressBackStackPush = false
                 previousSelectedEntry = selectedEntry
-                // New doc — visibleBlocks will repopulate from 0 upward
-                // as blocks appear; reset the mirror so we don't carry
-                // the leaving doc's value.
-                currentTopBlock = 0
             }
             guard !suppressBackStackPush,
                   let prev = previousSelectedEntry,
                   prev.path != selectedEntry?.path else { return }
             backStack.append(NavSnapshot(entry: prev, topBlockIndex: leavingTop))
             forwardStack.removeAll()
-        }
-        .onChange(of: topVisibleBlock) { newValue in
-            currentTopBlock = newValue
         }
     }
 
@@ -2132,7 +2122,7 @@ struct ContentView: View {
     private func goBack() {
         guard let prev = backStack.popLast() else { return }
         if let current = selectedEntry {
-            forwardStack.append(NavSnapshot(entry: current, topBlockIndex: currentTopBlock))
+            forwardStack.append(NavSnapshot(entry: current, topBlockIndex: topVisibleBlock))
         }
         applySnapshot(prev)
     }
@@ -2140,7 +2130,7 @@ struct ContentView: View {
     private func goForward() {
         guard let next = forwardStack.popLast() else { return }
         if let current = selectedEntry {
-            backStack.append(NavSnapshot(entry: current, topBlockIndex: currentTopBlock))
+            backStack.append(NavSnapshot(entry: current, topBlockIndex: topVisibleBlock))
         }
         applySnapshot(next)
     }
@@ -2151,7 +2141,7 @@ struct ContentView: View {
     /// nothing is loaded yet.
     private func pushSameDocSnapshot() {
         guard let current = selectedEntry else { return }
-        backStack.append(NavSnapshot(entry: current, topBlockIndex: currentTopBlock))
+        backStack.append(NavSnapshot(entry: current, topBlockIndex: topVisibleBlock))
         forwardStack.removeAll()
     }
 
@@ -2698,16 +2688,12 @@ struct ContentView: View {
         }
     }
 
-    /// Persist the current scroll anchor for `entry`. Reads `topVisibleBlock`
-    /// directly (== `visibleBlocks.min()`) rather than the `currentTopBlock`
-    /// mirror, because the back-stack handler on `body` resets
-    /// `currentTopBlock = 0` in its defer block, and SwiftUI's invocation
-    /// order across multiple onChange handlers for the same key isn't
-    /// guaranteed — empirically that defer can fire before this save runs.
-    /// `visibleBlocks` is safe to read here: it's only wiped by the
-    /// `.onChange(of: rawMarkdown)` handler, which fires on the *next*
-    /// runloop tick after `loadCurrentEntry` mutates `rawMarkdown`, well
-    /// after we've already saved.
+    /// Persist the current scroll anchor for `entry`. Reads
+    /// `topVisibleBlock` (== `visibleBlocks.min()`). `visibleBlocks` is
+    /// safe to read here: it's only wiped by the `.onChange(of: rawMarkdown)`
+    /// handler, which fires on the *next* runloop tick after
+    /// `loadCurrentEntry` mutates `rawMarkdown`, well after we've
+    /// already saved.
     ///
     /// Caller must invoke this BEFORE any code path that mutates `rawMarkdown`
     /// for a different file — otherwise `blocks` will already reflect the

--- a/mdv/ThemeManager.swift
+++ b/mdv/ThemeManager.swift
@@ -408,7 +408,13 @@ extension CodePalette {
 extension MDVTheme {
     /// Mirror of `Theme.gitHub`'s shape but with explicit per-theme colors. Same
     /// block builders so spacing/typography stays consistent across themes.
-    var markdownTheme: Theme {
+    var markdownTheme: Theme { markdownTheme(scale: 1.0) }
+
+    /// Same as `markdownTheme` but multiplies the body font size by `scale`.
+    /// Heading sizes are em-relative so they scale automatically with body;
+    /// per-element point spacing is left as-is to match browser-style zoom
+    /// (text grows but the column doesn't change shape).
+    func markdownTheme(scale: CGFloat) -> Theme {
         let bg = self.background
         let sbg = self.secondaryBackground
         let txt = self.text
@@ -422,7 +428,7 @@ extension MDVTheme {
         let strong = self.strong
 
         let family = self.bodyFontFamily
-        let bodySize = self.baseFontSize
+        let bodySize = self.baseFontSize * scale
         let lineEm = self.paragraphLineSpacingEm
         let h1 = self.h1SizeEm
         let h2 = self.h2SizeEm
@@ -965,16 +971,30 @@ final class ThemeManager: ObservableObject {
     static let systemDisplayName = "System"
 
     @AppStorage("mdv_theme_id") private var storedID: String = MDVTheme.default.id
+    @AppStorage("mdv_font_scale") private var storedFontScale: Double = 1.0
 
     /// What the user picked — may be `systemID`. Use this for menu
     /// checkmarks; use `current` for actual rendering.
     @Published private(set) var selectedID: String = MDVTheme.default.id
     @Published var current: MDVTheme = .default
 
+    /// Persistent zoom multiplier applied on top of the active theme's
+    /// `baseFontSize`. 1.0 = theme default. Stepped via `zoomIn` /
+    /// `zoomOut` / `resetZoom`; clamped to `[fontScaleMin, fontScaleMax]`.
+    @Published var fontScale: Double = 1.0
+
+    /// Zoom step (10%) and floor/ceiling. The floor stops a font from
+    /// becoming illegibly small; the ceiling avoids body type that
+    /// overflows the column at typical window sizes.
+    static let fontScaleStep = 0.10
+    static let fontScaleMin  = 0.60
+    static let fontScaleMax  = 2.50
+
     private var appearanceObservation: NSKeyValueObservation?
 
     init() {
         self.selectedID = storedID
+        self.fontScale = Self.clampScale(storedFontScale)
         self.current = Self.resolve(id: storedID)
         // KVO on effectiveAppearance: the OS posts when the user toggles
         // dark mode, when scheduled night-shift fires, or when the
@@ -1002,6 +1022,24 @@ final class ThemeManager: ObservableObject {
         selectedID = id
         storedID = id
         current = Self.resolve(id: id)
+    }
+
+    func zoomIn()    { setFontScale(fontScale + Self.fontScaleStep) }
+    func zoomOut()   { setFontScale(fontScale - Self.fontScaleStep) }
+    func resetZoom() { setFontScale(1.0) }
+
+    private func setFontScale(_ s: Double) {
+        let clamped = Self.clampScale(s)
+        // Round to one decimal so repeated +/− don't accrue float drift
+        // (1.0 + 0.1 + 0.1 ≠ 1.2 exactly otherwise).
+        let snapped = (clamped * 10).rounded() / 10
+        guard snapped != fontScale else { return }
+        fontScale = snapped
+        storedFontScale = snapped
+    }
+
+    private static func clampScale(_ s: Double) -> Double {
+        min(max(s, fontScaleMin), fontScaleMax)
     }
 
     private func systemAppearanceChanged() {

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -108,6 +108,21 @@ struct mdvApp: App {
                 }
                 .keyboardShortcut("s", modifiers: [.command, .control])
                 Divider()
+                // Zoom: scales body type via ThemeManager.fontScale.
+                // Headings are em-relative so they scale with body. ⌘= is
+                // the macOS-standard "zoom in" binding (same physical key
+                // as ⌘+ — shift is irrelevant under .command). ⌘0 is
+                // already taken by Jump-to-Placeholder, so Actual Size
+                // gets a menu item only.
+                Button("Zoom In") { themes.zoomIn() }
+                    .keyboardShortcut("=", modifiers: .command)
+                    .disabled(themes.fontScale >= ThemeManager.fontScaleMax)
+                Button("Zoom Out") { themes.zoomOut() }
+                    .keyboardShortcut("-", modifiers: .command)
+                    .disabled(themes.fontScale <= ThemeManager.fontScaleMin)
+                Button("Actual Size") { themes.resetZoom() }
+                    .disabled(themes.fontScale == 1.0)
+                Divider()
                 Toggle(
                     themes.current.smartTypographyAllowed
                         ? "Smart Typography"


### PR DESCRIPTION
## Summary

- **Zoom**: \`ThemeManager.fontScale\` is a persisted (\`@AppStorage(\"mdv_font_scale\")\`) multiplier on top of \`MDVTheme.baseFontSize\`. \`MDVTheme.markdownTheme(scale:)\` multiplies body size; headings are em-relative so they scale automatically. Per-element point spacing is left as-is — matches browser zoom feel (text grows, column doesn't change shape).
- **Hotkeys**: View → **Zoom In** (⌘=, also catches ⌘+ since shift is irrelevant under .command), **Zoom Out** (⌘−), **Actual Size** (menu only — ⌘0 is reserved for Jump to Placeholder). 10% steps, clamped to \`[0.6, 2.5]\`. Menu items disable at the floor / ceiling / 100% respectively.
- **HUD**: macOS volume/brightness-style transient overlay showing the current percentage, debounced via a \`DispatchWorkItem\` so repeated zoom keystrokes keep the HUD visible without flicker. Auto-dismisses ~0.9 s after the last change.
- **Theme picker checkmarks**: switched from \`Label(_:systemImage:)\` (which under-renders inside macOS menus) to \`Toggle\` inside the \`Menu\`. Toggle in a macOS Menu renders as a native checked menu item — system-drawn checkmark, proper indentation for unselected siblings — for both the \"System\" entry and each MDVTheme. Setter ignores \`false\` because there's no \"unchecked theme\" state; picking a different one is how you switch.

## Test plan

- [ ] \`./build.sh debug\` and \`./build.sh release\` build clean.
- [ ] ⌘= zooms body type up in 10% steps; ⌘− zooms down; the HUD shows the current %.
- [ ] HUD stays visible while you keep tapping; fades out ~0.9 s after the last keystroke.
- [ ] **Actual Size** menu item is disabled at 100% and resets the scale otherwise.
- [ ] Setting persists across launches.
- [ ] Headings scale proportionally with body across all themes (Charcoal, Sevilla, Twilight, OpenDyslexic, etc.).
- [ ] Toolbar paintpalette menu shows a system checkmark next to the active theme; \"System\" shows it when sentinel-selected.