### PR TITLE
Block-level selection + copy as markdown

### DIFF
--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -191,6 +191,7 @@ struct ContentView: View {
     @State private var currentMatchIndex: Int = 0
     @State private var findFieldRequestFocus: Bool = false
     @StateObject private var keyMonitor = KeyMonitor()
+    @StateObject private var selectionEscapeMonitor = SelectionEscapeMonitor()
 
     // Global (cross-history) search
     @State private var globalQuery: String = ""
@@ -251,6 +252,40 @@ struct ContentView: View {
             monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
                 if event.keyCode == 53 {
                     onEscape()
+                    return nil
+                }
+                return event
+            }
+        }
+
+        func uninstall() {
+            if let m = monitor {
+                NSEvent.removeMonitor(m)
+                monitor = nil
+            }
+        }
+
+        deinit { uninstall() }
+    }
+
+    /// Always-on Esc handler that clears the block selection when one
+    /// exists. Separate from `KeyMonitor` (which only lives while find is
+    /// open and would clobber its install/uninstall lifecycle) and from
+    /// any text-field Esc handling (we read the field-editor state to
+    /// avoid stealing Esc from a focused field). The closure pattern
+    /// re-reads state via the assigned blocks rather than capturing it
+    /// at install time, so the closure sees the live values.
+    final class SelectionEscapeMonitor: ObservableObject {
+        var shouldHandle: () -> Bool = { false }
+        var onEscape: () -> Void = {}
+        private var monitor: Any?
+
+        func install() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                if event.keyCode == 53, self.shouldHandle() {
+                    self.onEscape()
                     return nil
                 }
                 return event
@@ -496,6 +531,20 @@ struct ContentView: View {
         .onAppear {
             paneTracker.sidebarRightEdge = sidebarCollapsed ? 0 : (sidebarWidth + 8) // include drag handle width
             paneTracker.install()
+            // Esc-to-clear-selection. The closures re-read state every time
+            // they fire, so we don't have to reinstall the monitor when
+            // `selectedBlocks` or `isSearching` change. `shouldHandle`
+            // gates on (selection non-empty) AND (find bar closed) AND
+            // (no field editor focused) — Esc inside the find bar is
+            // owned by `keyMonitor`, and Esc inside any other text field
+            // belongs to that field.
+            selectionEscapeMonitor.shouldHandle = {
+                !selectedBlocks.isEmpty && !isSearching && !mdvApp.isFieldEditorFocused()
+            }
+            selectionEscapeMonitor.onEscape = {
+                selectedBlocks = []
+            }
+            selectionEscapeMonitor.install()
             if let url = initialURL {
                 loadFile(url)
             } else if let last = history.entries.first {
@@ -511,6 +560,7 @@ struct ContentView: View {
                 persistScrollPosition(for: entry)
             }
             paneTracker.uninstall()
+            selectionEscapeMonitor.uninstall()
         }
         .onChange(of: sidebarWidth) { newValue in
             if !sidebarCollapsed {

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -107,6 +107,22 @@ struct ContentView: View {
     /// each block's .onAppear / .onDisappear. The minimum is the topmost
     /// visible block, which is what we anchor a new bookmark to.
     @State private var visibleBlocks: Set<Int> = []
+
+    // Selection model — block-level. The user click-drags to select whole
+    // blocks at a time (no fine-grained text selection); ⌘C copies the
+    // selected blocks' source markdown joined with `\n\n`. If the selection
+    // covers any heading, that heading's section is auto-expanded so
+    // dragging across a heading line "feels" like selecting the section.
+    /// Block indices in the current selection.
+    @State private var selectedBlocks: Set<Int> = []
+    /// Block where the active drag started, or nil when no drag in flight.
+    /// Captured on the first `.onChanged` tick so subsequent ticks compute
+    /// the range from a stable origin.
+    @State private var dragSelectionStart: Int? = nil
+    /// Per-block frames in the markdown content's coordinate space, used
+    /// to map a drag's `value.location` back to a block index. Populated
+    /// by a PreferenceKey emitted from each block's `.background`.
+    @State private var blockFrames: [Int: CGRect] = [:]
     /// Block the mouse is currently hovering. Drives the bookmark-anchor
     /// indicator (subtle accent stripe + tint) so the user can see what
     /// ⌘D will bookmark — there's no caret in a viewer.
@@ -347,7 +363,9 @@ struct ContentView: View {
             forgetExternalEditor: { editorAppPath = "" },
             navigateBack: goBack,
             navigateForward: goForward,
-            toggleSidebar: toggleSidebar
+            toggleSidebar: toggleSidebar,
+            copyMarkdown: copySelectionAsMarkdown,
+            selectAllBlocks: selectAllBlocks
         ))
         .onOpenURL { url in
             loadFile(url)
@@ -378,6 +396,13 @@ struct ContentView: View {
         }
         .onChange(of: rawMarkdown) { _ in
             if isSearching { recomputeMatches() }
+            // Drop the block selection when the document content changes.
+            // FileWatcher reloads (external editor save) and history-driven
+            // doc swaps both come through here; carrying the selection
+            // across either is wrong — block indices no longer refer to the
+            // same content.
+            selectedBlocks = []
+            blockFrames = [:]
             // Visible-block tracking carries indices from the leaving doc.
             // We can't just `removeAll()`: SwiftUI's `ForEach(id: \.offset)`
             // keeps blocks with the same offset mounted across a doc swap,
@@ -1186,11 +1211,24 @@ struct ContentView: View {
                                             .animation(.easeOut(duration: 0.18), value: isSearching)
                                             .animation(.easeOut(duration: 0.12), value: hoveredBlock)
                                     )
+                                    .background(
+                                        // Selection highlight — paints over the block-background
+                                        // tint. Accent at 0.18 opacity matches macOS
+                                        // `selectedContentBackgroundColor` density without
+                                        // saturating the body text underneath.
+                                        Group {
+                                            if selectedBlocks.contains(idx) {
+                                                RoundedRectangle(cornerRadius: 4)
+                                                    .fill(themes.current.accent.opacity(0.18))
+                                            }
+                                        }
+                                        .animation(.easeOut(duration: 0.10), value: selectedBlocks)
+                                    )
                                     .overlay(alignment: .leading) {
                                         // Accent stripe along the left edge of the hovered block —
                                         // this is the "you will bookmark here" affordance, since a
                                         // read-only viewer has no insertion caret.
-                                        if hoveredBlock == idx && highlightColor(forBlock: idx) == .clear {
+                                        if hoveredBlock == idx && highlightColor(forBlock: idx) == .clear && !selectedBlocks.contains(idx) {
                                             Rectangle()
                                                 .fill(themes.current.accent)
                                                 .frame(width: 2)
@@ -1198,6 +1236,19 @@ struct ContentView: View {
                                                 .transition(.opacity)
                                         }
                                     }
+                                    .background(
+                                        // Frame tracker. PreferenceKey accumulates frames from
+                                        // every block; ScrollView's `.onPreferenceChange` reads
+                                        // them and stashes in `blockFrames` so the drag gesture
+                                        // can map cursor y-coords back to a block index.
+                                        GeometryReader { proxy in
+                                            Color.clear.preference(
+                                                key: BlockFramesKey.self,
+                                                value: [idx: proxy.frame(in: .named("markdownContent"))]
+                                            )
+                                        }
+                                    )
+                                    .contentShape(Rectangle())
                                     .id("block-\(idx)")
                                     .onAppear { visibleBlocks.insert(idx) }
                                     .onDisappear {
@@ -1211,14 +1262,60 @@ struct ContentView: View {
                                             hoveredBlock = nil
                                         }
                                     }
+                                    .onTapGesture(count: 2) {
+                                        // Double-click on a heading → select the whole section.
+                                        // Non-heading blocks: passthrough, no-op (single-click
+                                        // handler clears selection below).
+                                        if isHeadingBlock(idx) {
+                                            selectSection(headingAt: idx)
+                                        }
+                                    }
+                                    .onTapGesture(count: 1) {
+                                        // Single click anywhere clears the selection — matches the
+                                        // standard Finder/Notes behavior of dropping selection on
+                                        // a stray click.
+                                        if !selectedBlocks.isEmpty {
+                                            selectedBlocks = []
+                                        }
+                                    }
                             }
                         }
-                        .textSelection(.enabled)
                         .padding(.horizontal, themes.current.articleHorizontalPadding)
                         .padding(.vertical, 28)
                         .frame(maxWidth: themes.current.articleMaxWidth ?? .infinity, alignment: .leading)
                         .frame(maxWidth: .infinity,
                                alignment: themes.current.articleMaxWidth == nil ? .leading : .center)
+                        .coordinateSpace(name: "markdownContent")
+                        .onPreferenceChange(BlockFramesKey.self) { newFrames in
+                            // Replace rather than merge — when blocks reflow on theme/font
+                            // change, stale frames for re-rendered indices need to clear.
+                            blockFrames = newFrames
+                        }
+                        .simultaneousGesture(
+                            // Block-level drag-to-select. `simultaneousGesture` rather
+                            // than `.gesture` so child `.onTapGesture` handlers on each
+                            // block still fire on bare clicks — a parent
+                            // `.gesture(DragGesture)` (even with minimumDistance > 0)
+                            // suppresses descendants' tap recognizers, so single-click
+                            // to clear the selection wouldn't fire reliably. Drag-only
+                            // path is fine here because tap and drag are mutually
+                            // exclusive at the user level: a click without movement
+                            // never triggers the drag's `onChanged` (translation stays
+                            // 0), and a movement-bearing drag never delivers a tap to
+                            // the block underneath.
+                            DragGesture(minimumDistance: 4, coordinateSpace: .named("markdownContent"))
+                                .onChanged { value in
+                                    if dragSelectionStart == nil {
+                                        dragSelectionStart = blockAt(y: value.startLocation.y)
+                                    }
+                                    guard let start = dragSelectionStart,
+                                          let end = blockAt(y: value.location.y) else { return }
+                                    updateDragSelection(start: start, end: end)
+                                }
+                                .onEnded { _ in
+                                    dragSelectionStart = nil
+                                }
+                        )
                     }
                     .onChange(of: currentMatchIndex) { _ in
                         scrollToCurrentMatch(proxy: proxy)
@@ -1370,6 +1467,101 @@ struct ContentView: View {
         }
         flush()
         return result
+    }
+
+    // MARK: - Block selection
+
+    /// True if the block at `idx` is an ATX heading (`#`, `##`, `###`).
+    /// Used to gate the double-click-selects-section affordance and to
+    /// trigger section-expansion during a drag.
+    private func isHeadingBlock(_ idx: Int) -> Bool {
+        tocHeadings.contains(where: { $0.blockIndex == idx })
+    }
+
+    /// Range of blocks that make up the section starting at the heading
+    /// in `idx` — heading included, ending at the next heading of the
+    /// *same or higher* level (or end of document). Mirrors how readers
+    /// think about "this section": H2 ends at the next H2 or H1, not at
+    /// the next H3.
+    private func sectionRange(forHeadingAt idx: Int) -> Range<Int> {
+        guard let h = tocHeadings.first(where: { $0.blockIndex == idx }) else {
+            return idx..<idx + 1
+        }
+        let endIdx = tocHeadings.first(where: {
+            $0.blockIndex > idx && $0.level <= h.level
+        })?.blockIndex ?? blocks.count
+        return idx..<endIdx
+    }
+
+    /// Map a y-coordinate (in `markdownContent` space) to the index of
+    /// the block it falls inside. Returns nil before frames are populated
+    /// or when the cursor is in the gap between blocks.
+    private func blockAt(y: CGFloat) -> Int? {
+        // Strict containment first.
+        if let hit = blockFrames.first(where: { _, frame in
+            frame.minY <= y && y <= frame.maxY
+        })?.key {
+            return hit
+        }
+        // In the inter-block gap: snap to whichever block we're closest
+        // to. Without this, dragging through the LazyVStack spacing would
+        // produce momentary nil and freeze the selection.
+        let above = blockFrames.filter { $0.value.maxY < y }.max(by: { $0.value.maxY < $1.value.maxY })
+        let below = blockFrames.filter { $0.value.minY > y }.min(by: { $0.value.minY < $1.value.minY })
+        switch (above, below) {
+        case let (.some(a), .some(b)):
+            return (y - a.value.maxY) <= (b.value.minY - y) ? a.key : b.key
+        case let (.some(a), nil): return a.key
+        case let (nil, .some(b)): return b.key
+        default: return nil
+        }
+    }
+
+    /// Drag-selection updater. Computes the natural [min, max] range from
+    /// the drag's start/end blocks, then expands for any heading whose
+    /// block falls inside that range — so dragging *through* a heading
+    /// pulls the rest of that section in. Iterates until stable so an
+    /// expansion that pulls in another heading also expands.
+    private func updateDragSelection(start: Int, end: Int) {
+        var lower = min(start, end)
+        var upper = max(start, end) + 1
+
+        var changed = true
+        while changed {
+            changed = false
+            for h in tocHeadings where h.blockIndex >= lower && h.blockIndex < upper {
+                let span = sectionRange(forHeadingAt: h.blockIndex)
+                if span.lowerBound < lower { lower = span.lowerBound; changed = true }
+                if span.upperBound > upper { upper = span.upperBound; changed = true }
+            }
+        }
+        selectedBlocks = Set(lower..<upper)
+    }
+
+    /// Select the entire section that begins at the heading in `idx`.
+    /// Triggered by double-click on a heading block.
+    private func selectSection(headingAt idx: Int) {
+        let span = sectionRange(forHeadingAt: idx)
+        selectedBlocks = Set(span)
+    }
+
+    /// Replace the selection with every block in the document.
+    private func selectAllBlocks() {
+        selectedBlocks = Set(0..<blocks.count)
+    }
+
+    /// Copy the selected blocks' source markdown to the pasteboard,
+    /// joined by `\n\n` so paragraph breaks survive a round-trip back
+    /// into another markdown document. No-op when nothing is selected.
+    private func copySelectionAsMarkdown() {
+        guard !selectedBlocks.isEmpty else { return }
+        let sorted = selectedBlocks.sorted()
+        let text = sorted.compactMap { idx in
+            idx < blocks.count ? blocks[idx] : nil
+        }.joined(separator: "\n\n")
+        guard !text.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
     }
 
     // MARK: - Table of Contents
@@ -2733,6 +2925,21 @@ struct ContentView: View {
     }
 }
 
+// MARK: - Block frame tracking
+
+/// PreferenceKey that accumulates each block's frame (in the markdown
+/// content's coordinate space) as the LazyVStack lays out. The drag
+/// gesture reads this dictionary to map cursor y-coords back to a block
+/// index. We `merge` rather than replace per-key so blocks above the
+/// viewport that haven't been laid out this pass don't drop their
+/// frames.
+private struct BlockFramesKey: PreferenceKey {
+    static var defaultValue: [Int: CGRect] = [:]
+    static func reduce(value: inout [Int: CGRect], nextValue: () -> [Int: CGRect]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
 // MARK: - Find text field
 
 struct FindField: NSViewRepresentable {
@@ -2873,9 +3080,52 @@ private struct NotificationHandlers: ViewModifier {
     let navigateBack: () -> Void
     let navigateForward: () -> Void
     let toggleSidebar: () -> Void
+    let copyMarkdown: () -> Void
+    let selectAllBlocks: () -> Void
 
     func body(content: Content) -> some View {
         content
+            .modifier(SelectionAndFileHandlers(
+                copyMarkdown: copyMarkdown,
+                selectAllBlocks: selectAllBlocks,
+                toggleSidebar: toggleSidebar,
+                openFile: openFile,
+                openFileInNewWindow: openFileInNewWindow,
+                openURLInWindow: openURLInWindow,
+                findInDocument: findInDocument,
+                searchHistory: searchHistory
+            ))
+            .modifier(BookmarkAndEditorHandlers(
+                toggleBookmark: toggleBookmark,
+                openBookmarkSlot: openBookmarkSlot,
+                setPlaceholder: setPlaceholder,
+                jumpToPlaceholder: jumpToPlaceholder,
+                chooseExternalEditor: chooseExternalEditor,
+                openInExternalEditor: openInExternalEditor,
+                forgetExternalEditor: forgetExternalEditor,
+                navigateBack: navigateBack,
+                navigateForward: navigateForward
+            ))
+    }
+}
+
+/// Half of `NotificationHandlers`. Splitting the long `.onReceive` chain
+/// keeps the SwiftUI type-checker under its expression-complexity budget
+/// — the combined view exceeded it after copy/select-all were added.
+private struct SelectionAndFileHandlers: ViewModifier {
+    let copyMarkdown: () -> Void
+    let selectAllBlocks: () -> Void
+    let toggleSidebar: () -> Void
+    let openFile: () -> Void
+    let openFileInNewWindow: () -> Void
+    let openURLInWindow: (URL) -> Void
+    let findInDocument: () -> Void
+    let searchHistory: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .copyMarkdown)) { _ in copyMarkdown() }
+            .onReceive(NotificationCenter.default.publisher(for: .selectAllBlocks)) { _ in selectAllBlocks() }
             .onReceive(NotificationCenter.default.publisher(for: .toggleSidebar)) { _ in toggleSidebar() }
             .onReceive(NotificationCenter.default.publisher(for: .openFile)) { _ in openFile() }
             .onReceive(NotificationCenter.default.publisher(for: .openFileInNewWindow)) { _ in openFileInNewWindow() }
@@ -2884,6 +3134,22 @@ private struct NotificationHandlers: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .findInDocument)) { _ in findInDocument() }
             .onReceive(NotificationCenter.default.publisher(for: .searchHistory)) { _ in searchHistory() }
+    }
+}
+
+private struct BookmarkAndEditorHandlers: ViewModifier {
+    let toggleBookmark: () -> Void
+    let openBookmarkSlot: (Int) -> Void
+    let setPlaceholder: () -> Void
+    let jumpToPlaceholder: () -> Void
+    let chooseExternalEditor: () -> Void
+    let openInExternalEditor: () -> Void
+    let forgetExternalEditor: () -> Void
+    let navigateBack: () -> Void
+    let navigateForward: () -> Void
+
+    func body(content: Content) -> some View {
+        content
             .onReceive(NotificationCenter.default.publisher(for: .toggleBookmark)) { _ in toggleBookmark() }
             .onReceive(NotificationCenter.default.publisher(for: .openBookmarkSlot)) { notif in
                 if let n = notif.object as? Int { openBookmarkSlot(n) }

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -73,6 +73,39 @@ struct mdvApp: App {
                     }
                 }
             }
+            // Replace the system pasteboard group so ⌘C / ⌘A are routed
+            // through our handlers. Cut / Paste are kept as plain
+            // responder-chain dispatches so text fields (find bar, sidebar
+            // search, etc.) keep working. Copy / Select-All check whether
+            // the focused responder is a field editor and either delegate
+            // to it via the responder chain or fall through to the
+            // markdown-block handlers in ContentView.
+            CommandGroup(replacing: .pasteboard) {
+                Button("Cut") {
+                    NSApp.sendAction(#selector(NSText.cut(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("x", modifiers: .command)
+                Button("Copy") {
+                    if mdvApp.isFieldEditorFocused() {
+                        NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
+                    } else {
+                        NotificationCenter.default.post(name: .copyMarkdown, object: nil)
+                    }
+                }
+                .keyboardShortcut("c", modifiers: .command)
+                Button("Paste") {
+                    NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("v", modifiers: .command)
+                Button("Select All") {
+                    if mdvApp.isFieldEditorFocused() {
+                        NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
+                    } else {
+                        NotificationCenter.default.post(name: .selectAllBlocks, object: nil)
+                    }
+                }
+                .keyboardShortcut("a", modifiers: .command)
+            }
             CommandGroup(after: .pasteboard) {
                 Divider()
                 Button("Find…") {
@@ -182,6 +215,20 @@ struct mdvApp: App {
         }
         return "Slot \(n) — Empty"
     }
+
+    /// True if the key window's first responder is a text field editor.
+    /// Used by the Edit > Copy / Select All buttons to decide whether to
+    /// delegate to the responder chain (text field present) or fall
+    /// through to the markdown block-selection handlers (markdown view
+    /// active). NSText.isFieldEditor catches the field editor that
+    /// NSTextField rents from the window; explicit NSTextView covers
+    /// SwiftUI-driven text views in case any show up.
+    static func isFieldEditorFocused() -> Bool {
+        guard let resp = NSApp.keyWindow?.firstResponder else { return false }
+        if let text = resp as? NSText, text.isFieldEditor { return true }
+        if resp is NSTextView { return true }
+        return false
+    }
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -215,4 +262,6 @@ extension Notification.Name {
     static let navigateBack = Notification.Name("navigateBack")
     static let navigateForward = Notification.Name("navigateForward")
     static let toggleSidebar = Notification.Name("toggleSidebar")
+    static let copyMarkdown = Notification.Name("copyMarkdown")
+    static let selectAllBlocks = Notification.Name("selectAllBlocks")
 }


### PR DESCRIPTION
## Summary

Replace MarkdownUI's `.textSelection(.enabled)` (rendered-text copy) with a block-level drag-select model that copies *source markdown*.

- **Click-drag** highlights blocks the cursor passes over. If any heading falls inside the dragged range, that heading's section is auto-expanded down to the next same-or-higher-level heading — so dragging across a heading line "feels" like grabbing the section. Iterates until stable, so an expansion that pulls in another heading also expands.
- **Double-click on a heading** selects its section.
- **⌘A** selects every block.
- **⌘C** copies the selected blocks' source markdown joined with `\n\n`. Verified end-to-end: backticks, asterisks, bullet lines, HRs all preserved.
- **Single-click** clears the selection. **Esc** also clears (gated to not-searching AND no-field-editor-focused so it doesn't steal Esc from the find bar or any text field).
- **Visual indicator**: per-block `theme.accent` fill at 0.18 opacity — matches the macOS `selectedContentBackgroundColor` density. Subtle in pale-accent themes (Standard Erin), more pronounced in saturated-accent themes (Solarium, Twilight).

## Implementation notes

- Per-block frames tracked via a `BlockFramesKey` PreferenceKey on a named `markdownContent` coordinate space. The drag gesture maps cursor y → block index, with snap-to-nearest in the inter-block gap so dragging through LazyVStack spacing doesn't drop into nil.
- Drag attached as `.simultaneousGesture` rather than `.gesture` — a parent `.gesture(DragGesture)` (even with `minimumDistance > 0`) suppresses descendant taps, so per-block single-click-to-clear wouldn't fire reliably.
- `Edit > Cut/Copy/Paste/Select All` command group replaced. Copy / Select All check `mdvApp.isFieldEditorFocused()`; if a field is focused they delegate via `NSApp.sendAction(_:to: nil)` so the responder chain handles the field's local copy/select-all. Cut and Paste always go through the responder chain.
- Selection auto-clears when `rawMarkdown` changes (file swap or FileWatcher reload) so block indices don't leak across content.
- `NotificationHandlers` split into two ViewModifiers — the chain blew the SwiftUI type-checker budget after copy/select-all were added.
- New `SelectionEscapeMonitor` for Esc-to-clear, with closures that re-read live state on each fire (so we don't have to reinstall on every selection / isSearching change).

## What's gone, what's traded

Fine-grained text selection inside a single block is no longer available — the click-drag-copy contract is whole blocks → markdown source. Trade-off implied by the user's "click-drag copy, as markdown" framing. Cmd+C in any text field still copies the field's text via responder chain.

## Test plan

- [ ] Drag across paragraphs → highlighted, ⌘C → markdown source on pasteboard
- [ ] Drag across a heading → that heading's section auto-expands to include the body
- [ ] Double-click heading → selects section
- [ ] ⌘A → every block highlighted; ⌘C → whole document as markdown
- [ ] Single-click clears selection; Esc clears selection
- [ ] ⌘C / ⌘A in find bar still copies / selects-all the field's text (responder chain delegation)
- [ ] Selection clears on file swap / external edit reload
- [ ] Visual highlight is visible across all themes (System, High Contrast, Sevilla, Charcoal, Solarium Daylight/Moonlight, Phosphor, Twilight, Standard Erin Light/Dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)