### PR TITLE
Parse markdown once per document load, not per scroll frame

### DIFF
--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -23,7 +23,25 @@ struct ContentView: View {
     }
 
     @State private var selectedEntry: HistoryEntry?
-    @State private var rawMarkdown: String = ""
+
+    // Source of truth for the open document. `ParsedDocument` parses
+    // `blocks` and `tocHeadings` once on construction; `rawMarkdown`
+    // below is a thin getter/setter over `document.raw` so every
+    // existing call site keeps the same shape. Before this, `blocks`
+    // and `tocHeadings` were computed properties that re-split the
+    // entire raw string on every access — and `.modifier(BlockTextSelection(
+    // isHeading: isHeadingBlock(idx)))` per row meant a scroll tick did
+    // O(N) full re-parses, pegging the main thread on
+    // GraphHost.flushTransactions.
+    @State private var document: ParsedDocument = .empty
+    private var rawMarkdown: String {
+        get { document.raw }
+        nonmutating set {
+            if newValue != document.raw {
+                document = ParsedDocument(raw: newValue)
+            }
+        }
+    }
     @State private var sidebarWidth: CGFloat = 240
     @State private var dragHandleHovered = false
 
@@ -1372,54 +1390,7 @@ struct ContentView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: task)
     }
 
-    private var blocks: [String] {
-        // Fence-aware split. A blank line ends a paragraph block normally,
-        // but blank lines INSIDE a fenced code block (``` or ~~~) are part
-        // of the code and must not split the block — otherwise multi-
-        // paragraph code samples get shredded into separate single-line
-        // code-blocks-or-prose, which mangles syntax highlighting.
-        var result: [String] = []
-        var current: [String] = []
-        var fenceMarker: String? = nil  // nil → outside, "```" or "~~~" → inside
-        let lines = rawMarkdown.components(separatedBy: "\n")
-
-        func flush() {
-            let joined = current.joined(separator: "\n")
-                .trimmingCharacters(in: .newlines)
-            if !joined.isEmpty { result.append(joined) }
-            current.removeAll(keepingCapacity: true)
-        }
-
-        for line in lines {
-            let trimmedStart = line.drop(while: { $0 == " " })
-            if let marker = fenceMarker {
-                current.append(line)
-                if trimmedStart.hasPrefix(marker) {
-                    fenceMarker = nil
-                }
-                continue
-            }
-            if trimmedStart.hasPrefix("```") {
-                if !current.isEmpty { flush() }
-                current.append(line)
-                fenceMarker = "```"
-                continue
-            }
-            if trimmedStart.hasPrefix("~~~") {
-                if !current.isEmpty { flush() }
-                current.append(line)
-                fenceMarker = "~~~"
-                continue
-            }
-            if line.trimmingCharacters(in: .whitespaces).isEmpty {
-                flush()
-            } else {
-                current.append(line)
-            }
-        }
-        flush()
-        return result
-    }
+    private var blocks: [String] { document.blocks }
 
     // MARK: - Section copy
 
@@ -1470,31 +1441,7 @@ struct ContentView: View {
 
     // MARK: - Table of Contents
 
-    private var tocHeadings: [TOCHeading] {
-        var result: [TOCHeading] = []
-        for (idx, block) in blocks.enumerated() {
-            let trimmed = block.trimmingCharacters(in: .whitespacesAndNewlines)
-            // Skip fenced code blocks even if they start with #
-            if trimmed.hasPrefix("```") { continue }
-            let level: Int
-            let prefix: String
-            if trimmed.hasPrefix("### ") {
-                level = 3; prefix = "### "
-            } else if trimmed.hasPrefix("## ") {
-                level = 2; prefix = "## "
-            } else if trimmed.hasPrefix("# ") {
-                level = 1; prefix = "# "
-            } else {
-                continue
-            }
-            // Single-line headings only
-            let firstLine = trimmed.components(separatedBy: "\n").first ?? trimmed
-            let raw = String(firstLine.dropFirst(prefix.count))
-            let text = stripInlineMarkdown(raw)
-            result.append(TOCHeading(level: level, text: text, blockIndex: idx))
-        }
-        return result
-    }
+    private var tocHeadings: [TOCHeading] { document.tocHeadings }
 
     /// `tocHeadings`, optionally narrowed to entries matching `tocSearchQuery`
     /// (case-/diacritic-insensitive substring on the heading text). Empty
@@ -1505,26 +1452,6 @@ struct ContentView: View {
         return tocHeadings.filter {
             $0.text.range(of: q, options: [.caseInsensitive, .diacriticInsensitive]) != nil
         }
-    }
-
-    private func stripInlineMarkdown(_ s: String) -> String {
-        var out = s
-        // Trailing #'s of ATX headings
-        out = out.replacingOccurrences(of: #"\s+#+\s*$"#, with: "", options: .regularExpression)
-        // Inline code / bold / italic markers
-        out = out.replacingOccurrences(of: "**", with: "")
-        out = out.replacingOccurrences(of: "__", with: "")
-        out = out.replacingOccurrences(of: "`", with: "")
-        // Bare * and _ around words (single-char emphasis)
-        out = out.replacingOccurrences(of: #"(?<!\\)\*"#, with: "", options: .regularExpression)
-        out = out.replacingOccurrences(of: #"(?<![A-Za-z0-9])_(?=[^_]+_)"#, with: "", options: .regularExpression)
-        // Markdown links [text](url) → text
-        out = out.replacingOccurrences(
-            of: #"\[([^\]]+)\]\([^)]+\)"#,
-            with: "$1",
-            options: .regularExpression
-        )
-        return out.trimmingCharacters(in: .whitespaces)
     }
 
     // MARK: - Right inspector (TOC + Bookmarks)
@@ -2827,6 +2754,136 @@ struct ContentView: View {
         }
         return true
     }
+}
+
+/// Parsed markdown document: raw text plus its derived `blocks` and
+/// `tocHeadings`, computed once at construction. `ContentView` holds one
+/// of these as `@State` and exposes `rawMarkdown` as a thin accessor over
+/// `document.raw`, so existing read/write sites are unchanged but each
+/// scroll tick reads `blocks`/`tocHeadings` in O(1) instead of re-splitting
+/// the whole raw string per visible row.
+fileprivate struct ParsedDocument: Equatable {
+    let raw: String
+    let blocks: [String]
+    let tocHeadings: [ContentView.TOCHeading]
+
+    static let empty = ParsedDocument(raw: "", blocks: [], tocHeadings: [])
+
+    private init(raw: String, blocks: [String], tocHeadings: [ContentView.TOCHeading]) {
+        self.raw = raw
+        self.blocks = blocks
+        self.tocHeadings = tocHeadings
+    }
+
+    init(raw: String) {
+        let blocks = Self.parseBlocks(raw)
+        self.init(
+            raw: raw,
+            blocks: blocks,
+            tocHeadings: Self.parseTOC(blocks: blocks)
+        )
+    }
+
+    // `blocks` and `tocHeadings` are pure functions of `raw`, so equality
+    // on `raw` alone is sufficient and avoids walking two arrays.
+    static func == (lhs: ParsedDocument, rhs: ParsedDocument) -> Bool {
+        lhs.raw == rhs.raw
+    }
+
+    private static func parseBlocks(_ raw: String) -> [String] {
+        // Fence-aware split. A blank line ends a paragraph block normally,
+        // but blank lines INSIDE a fenced code block (``` or ~~~) are part
+        // of the code and must not split the block — otherwise multi-
+        // paragraph code samples get shredded into separate single-line
+        // code-blocks-or-prose, which mangles syntax highlighting.
+        var result: [String] = []
+        var current: [String] = []
+        var fenceMarker: String? = nil  // nil → outside, "```" or "~~~" → inside
+        let lines = raw.components(separatedBy: "\n")
+
+        func flush() {
+            let joined = current.joined(separator: "\n")
+                .trimmingCharacters(in: .newlines)
+            if !joined.isEmpty { result.append(joined) }
+            current.removeAll(keepingCapacity: true)
+        }
+
+        for line in lines {
+            let trimmedStart = line.drop(while: { $0 == " " })
+            if let marker = fenceMarker {
+                current.append(line)
+                if trimmedStart.hasPrefix(marker) {
+                    fenceMarker = nil
+                }
+                continue
+            }
+            if trimmedStart.hasPrefix("```") {
+                if !current.isEmpty { flush() }
+                current.append(line)
+                fenceMarker = "```"
+                continue
+            }
+            if trimmedStart.hasPrefix("~~~") {
+                if !current.isEmpty { flush() }
+                current.append(line)
+                fenceMarker = "~~~"
+                continue
+            }
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                flush()
+            } else {
+                current.append(line)
+            }
+        }
+        flush()
+        return result
+    }
+
+    private static func parseTOC(blocks: [String]) -> [ContentView.TOCHeading] {
+        var result: [ContentView.TOCHeading] = []
+        for (idx, block) in blocks.enumerated() {
+            let trimmed = block.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Skip fenced code blocks even if they start with #
+            if trimmed.hasPrefix("```") { continue }
+            let level: Int
+            let prefix: String
+            if trimmed.hasPrefix("### ") {
+                level = 3; prefix = "### "
+            } else if trimmed.hasPrefix("## ") {
+                level = 2; prefix = "## "
+            } else if trimmed.hasPrefix("# ") {
+                level = 1; prefix = "# "
+            } else {
+                continue
+            }
+            // Single-line headings only
+            let firstLine = trimmed.components(separatedBy: "\n").first ?? trimmed
+            let raw = String(firstLine.dropFirst(prefix.count))
+            let text = stripInlineMarkdown(raw)
+            result.append(ContentView.TOCHeading(level: level, text: text, blockIndex: idx))
+        }
+        return result
+    }
+}
+
+fileprivate func stripInlineMarkdown(_ s: String) -> String {
+    var out = s
+    // Trailing #'s of ATX headings
+    out = out.replacingOccurrences(of: #"\s+#+\s*$"#, with: "", options: .regularExpression)
+    // Inline code / bold / italic markers
+    out = out.replacingOccurrences(of: "**", with: "")
+    out = out.replacingOccurrences(of: "__", with: "")
+    out = out.replacingOccurrences(of: "`", with: "")
+    // Bare * and _ around words (single-char emphasis)
+    out = out.replacingOccurrences(of: #"(?<!\\)\*"#, with: "", options: .regularExpression)
+    out = out.replacingOccurrences(of: #"(?<![A-Za-z0-9])_(?=[^_]+_)"#, with: "", options: .regularExpression)
+    // Markdown links [text](url) → text
+    out = out.replacingOccurrences(
+        of: #"\[([^\]]+)\]\([^)]+\)"#,
+        with: "$1",
+        options: .regularExpression
+    )
+    return out.trimmingCharacters(in: .whitespaces)
 }
 
 /// Per-block text-selection gating. Prose blocks have `.enabled` so the


### PR DESCRIPTION
## Summary

Scroll jitter on documents larger than a few KB came from `blocks` and
`tocHeadings` being computed properties that re-parsed the entire raw
markdown string on every access. The `LazyVStack(ForEach(blocks))`
applies `BlockTextSelection(isHeading: isHeadingBlock(idx))` per row,
and `isHeadingBlock` → `tocHeadings` → `blocks` triggered another full
re-parse, so each body re-eval did ~2N+1 full document parses.

Fix: parse once per document load into a `ParsedDocument` value type;
expose `rawMarkdown`, `blocks`, `tocHeadings` as thin accessors so
every existing call site is unchanged.

## Repro

Open any markdown file of ~5–10 KB or larger and scroll continuously.
`sample $(pgrep mdv) 5` will show the main thread pegged in
`GraphHost.flushTransactions` → `ContentView.tocHeadings.getter` →
`ContentView.blocks.getter`.

## Before / after

Sampling for 5 seconds while scrolling the same file:

| Metric | Before | After |
|---|---|---|
| Frames touching `blocks.getter` / `tocHeadings.getter` / `isHeadingBlock` | 234 | 2 |
| `GraphHost.flushTransactions` share of main thread | ~38% | ~1.6% |
| Main thread idle in `mach_msg2_trap` | ~0% | ~50% |

## What changed

- Added `ParsedDocument` (fileprivate value type at the end of
  `ContentView.swift`) that wraps `raw: String`, `blocks: [String]`,
  `tocHeadings: [ContentView.TOCHeading]`, parsed once in `init(raw:)`.
- Replaced `@State var rawMarkdown: String` with `@State var document:
  ParsedDocument` plus a computed `rawMarkdown` getter/setter over
  `document.raw`. Every existing `rawMarkdown = ...` and read site keeps
  working unchanged.
- `blocks` and `tocHeadings` are now one-liners reading from `document`.
- Moved the existing parsing logic (the fence-aware splitter and
  `stripInlineMarkdown`) into `ParsedDocument` and a fileprivate free
  function respectively. No logic changes — just relocated.

## Test plan

- [ ] Open a large markdown file (multi-screen) and scroll — should be
      smooth, no main-thread saturation.
- [ ] Bookmarks: jump to a bookmark, verify the resolved block index
      still scrolls to the right place.
- [ ] TOC: heading list populates correctly, click-to-scroll works,
      filter search narrows the list.
- [ ] FileWatcher reload: edit the open file externally, verify the
      viewer updates and the scroll position holds.
- [ ] Doc swap via sidebar: visible-block tracking and scroll-position
      restore both still work.