### PR TITLE
Fix thematic-break rendering when Smart Typography is enabled

### DIFF
--- a/mdv/SmartTypography.swift
+++ b/mdv/SmartTypography.swift
@@ -36,6 +36,11 @@ func smartenMarkdown(_ source: String) -> String {
         return source
     }
 
+    // Thematic break: entire block is a horizontal-rule line (--- / ---- / * * * / etc.)
+    if looksLikeThematicBreakLine(trimmed) {
+        return source
+    }
+
     var result = ""
     result.reserveCapacity(source.count)
 
@@ -48,9 +53,25 @@ func smartenMarkdown(_ source: String) -> String {
     // URL containing `(` like `https://en.wikipedia.org/wiki/Foo_(disambig)`
     // doesn't close early.
     var linkParenDepth = 0
+    var atLineStart = true
 
     while i < source.endIndex {
         let c = source[i]
+
+        // ---- Thematic break line (setext heading underline or standalone HR) ----
+        // Emit verbatim so MarkdownUI can recognize it as a thematic break.
+        if atLineStart && (c == "-" || c == "*" || c == "_") && codeRun == 0 {
+            var end = i
+            while end < source.endIndex && source[end] != "\n" {
+                end = source.index(after: end)
+            }
+            if looksLikeThematicBreakLine(String(source[i..<end])) {
+                result.append(contentsOf: source[i..<end])
+                i = end
+                atLineStart = false
+                continue
+            }
+        }
 
         // ---- Backtick runs (inline code spans) ----
         if c == "`" {
@@ -72,6 +93,7 @@ func smartenMarkdown(_ source: String) -> String {
         }
 
         if codeRun > 0 {
+            atLineStart = (c == "\n")
             result.append(c)
             i = source.index(after: i)
             continue
@@ -89,6 +111,7 @@ func smartenMarkdown(_ source: String) -> String {
             continue
         }
         if linkParenDepth > 0 {
+            atLineStart = (c == "\n")
             result.append(c)
             if c == "(" { linkParenDepth += 1 }
             else if c == ")" {
@@ -185,11 +208,25 @@ func smartenMarkdown(_ source: String) -> String {
             continue
         }
 
+        atLineStart = (c == "\n")
         result.append(c)
         i = source.index(after: i)
     }
 
     return result
+}
+
+/// True if `line` (one logical line, no `\n`) is a CommonMark thematic break:
+/// 3+ occurrences of the same marker (`-`, `*`, or `_`), with optional spaces/tabs,
+/// and nothing else. Examples: `---`, `----`, `* * *`, `- - -`.
+private func looksLikeThematicBreakLine(_ line: String) -> Bool {
+    for marker: Character in ["-", "*", "_"] {
+        let onlyMarkerAndSpace = line.allSatisfy { $0 == marker || $0 == " " || $0 == "\t" }
+        if onlyMarkerAndSpace && line.filter({ $0 == marker }).count >= 3 {
+            return true
+        }
+    }
+    return false
 }
 
 /// True iff the block contains a GFM table separator row — a line whose

--- a/test-docs/README.md
+++ b/test-docs/README.md
@@ -28,6 +28,11 @@ history sidebar with the rest.
 - [toc-stress.md](toc-stress.md) — many headings at every level so
   you can exercise the TOC pane, the spyglass-collapse search, and
   the "On this page" affordances.
+- [thematic-break.md](thematic-break.md) — every CommonMark
+  thematic-break variant (`---`, `----`, `* * *`, `_ _ _`, `- - -`,
+  setext H2) plus inline dash sequences that must *not* become rules.
+  Useful for verifying thematic-break rendering with View → Smart
+  Typography on and off.
 
 ## Quick checklist
 

--- a/test-docs/thematic-break.md
+++ b/test-docs/thematic-break.md
@@ -1,0 +1,64 @@
+# Thematic Break — rendering test
+
+Three hyphens (standard):
+
+---
+
+Four hyphens:
+
+----
+
+Five hyphens:
+
+-----
+
+Ten hyphens:
+
+----------
+
+Asterisks:
+
+***
+
+Underscores:
+
+___
+
+With spaces between:
+
+- - -
+
+* * *
+
+_ _ _
+
+---
+
+## Setext H2 heading
+
+The following heading uses a setext-style underline of hyphens:
+
+This is a second-level heading
+----
+
+This is a regular paragraph after it.
+
+---
+
+## Smart typography near rules
+
+This paragraph contains an em-dash via `---`: word --- word.
+
+And here a range via `--`: 2020--2025.
+
+These transformations should work as usual; only horizontal rules should render as lines, not text.
+
+---
+
+## Edge cases
+
+Hyphens inside text (must not become a rule):
+
+A line with hyphens in the middle: foo --- bar and foo ---- bar.
+
+CLI flags must not be touched: `--verbose` and `--output`.


### PR DESCRIPTION
A small aside. I’m a big fan of native personal software for macOS—I’ve made my own Things alternative, a clipboard manager, and several more specialized apps (about 10 in total!), which I actively use myself. I don’t release them publicly because they’re very specific to my needs. But in your case, the app is excellent and can be useful for many people! Thank you for sharing it!

## Summary

Thematic breaks (`---`, `----`, `* * *`, etc.) rendered as plain text — or as stray em-dashes — whenever View → Smart Typography was enabled. The same bug broke setext H2 headings (`heading\n----`).

## Root cause

`smartenMarkdown` in `SmartTypography.swift` processes source character-by-character and converts every `---` run to an em-dash (`—`) **before** MarkdownUI parses the markdown. A standalone `----` block arrived at the renderer as `—-`, which cmark-gfm did not recognise as a thematic break and fell back to raw text. Similarly, a setext underline `----` was mangled into `—-`, so the heading above it lost its H2 styling.

This is the same class of bug that was fixed for GFM tables in #23 — smartening corrupting syntax that cmark-gfm relies on.

## Fix

Skip smartening for any line whose characters are entirely one marker (`-`, `*`, or `_`) with optional spaces/tabs, and at least three marker characters — the exact CommonMark thematic-break grammar (`- - -`, `***`, `____`, etc. all qualify).

Two guard layers in `SmartTypography.swift`:

- **Block-scope early exit** (`looksLikeThematicBreakLine(trimmed)`) — cheap check for the common case of a standalone rule block, mirrors the existing fenced-code and table guards.
- **Line-level look-ahead** inside the character loop (new `atLineStart` flag + look-ahead) — preserves thematic-break lines verbatim even when they appear inside a larger block, which is how setext H2 underlines arrive.

## What changed

- `mdv/SmartTypography.swift` — new `looksLikeThematicBreakLine` helper + two guards
- `test-docs/thematic-break.md` — new test document covering every CommonMark thematic-break variant and the setext H2 case (see test plan below)

## Test plan

Open `test-docs/thematic-break.md` with **View → Smart Typography on**:

- [x] `---`, `----`, `-----`, `----------` each render as a horizontal rule (not `—`, `—-`, etc.)
- [x] `***`, `___` render as horizontal rules
- [x] `- - -`, `* * *`, `_ _ _` (with spaces) render as horizontal rules
- [x] "This is a second-level heading" + `----` renders as an **H2 heading**, not two lines of plain text
- [x] `слово --- слово` in a prose paragraph still renders as `слово — слово` (em-dash conversion unaffected)
- [x] `2020--2025` still renders as `2020–2025` (en-dash conversion unaffected)
- [x] `foo --- bar` mid-sentence does **not** become a horizontal rule
- [x] `--verbose`, `--output` inside backtick spans are untouched

All passing. See screenshots below.

With **View → Smart Typography on**:

<img width="1219" height="1111" alt="image" src="https://github.com/user-attachments/assets/4c957716-a3e7-4399-8b17-06f94553a173" />

With **View → Smart Typography off**:

<img width="1219" height="1111" alt="image" src="https://github.com/user-attachments/assets/9d0135c0-5fb2-4be9-b32f-ab2b746eb70d" />

Screenshot **BEFORE** fix with **View → Smart Typography on**:

<img width="1219" height="1203" alt="image" src="https://github.com/user-attachments/assets/48ad6ab7-da43-4a9e-908d-740361853d9a" />

