### PR TITLE
Render unsupported Mermaid types (gantt, pie, etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build_icon/
 
 # macOS
 .DS_Store
+
+# Bundled third-party JS assets (downloaded by build setup, not committed)
+mdv/mermaid.min.js

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ of an evening while yelling at people about zoning reform.
 
 * Bookmarks, across all files, the first 5 of which are hotkeyed `CMD-[1-5]`, and a transient in-memory `CMD-0` placeholder. Every program must evolve until it manages bookmarks.
 
+* It renders **Mermaid diagrams** — flowcharts, sequence diagrams, ER diagrams, state diagrams, XY charts, gantt charts, and whatever else mermaid.js knows about. The native renderer (BeautifulMermaid) handles the common graph types; anything it can't render falls back to a bundled mermaid.js running in a WKWebView. Style picker included.
+
 * It may do other things I've forgotten about. 
 
 ## Installing

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,15 @@ chmod +x                         "$APP/Contents/Resources/mdv"
 # Bundle the in-app help doc; HelpManager copies it out to a stable path
 # under ~/Library/Application Support/mdv on demand so bookmarks survive.
 cp mdv/Help.md                   "$APP/Contents/Resources/Help.md"
-cp mdv/mermaid.min.js            "$APP/Contents/Resources/"
+# Download mermaid.min.js on demand so it stays out of git but CI can build.
+MERMAID_VERSION="11.4.1"
+MERMAID_JS="mdv/mermaid.min.js"
+if [ ! -f "$MERMAID_JS" ]; then
+    echo "→ downloading mermaid.js $MERMAID_VERSION"
+    curl -fsSL "https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/dist/mermaid.min.js" \
+         -o "$MERMAID_JS"
+fi
+cp "$MERMAID_JS"                 "$APP/Contents/Resources/"
 
 echo "→ codesigning (adhoc)"
 codesign --force --sign - --entitlements mdv/mdv.entitlements "$APP"

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ chmod +x                         "$APP/Contents/Resources/mdv"
 # Bundle the in-app help doc; HelpManager copies it out to a stable path
 # under ~/Library/Application Support/mdv on demand so bookmarks survive.
 cp mdv/Help.md                   "$APP/Contents/Resources/Help.md"
+cp mdv/mermaid.min.js            "$APP/Contents/Resources/"
 
 echo "→ codesigning (adhoc)"
 codesign --force --sign - --entitlements mdv/mdv.entitlements "$APP"

--- a/build.sh
+++ b/build.sh
@@ -40,13 +40,33 @@ chmod +x                         "$APP/Contents/Resources/mdv"
 # under ~/Library/Application Support/mdv on demand so bookmarks survive.
 cp mdv/Help.md                   "$APP/Contents/Resources/Help.md"
 # Download mermaid.min.js on demand so it stays out of git but CI can build.
+# We pin the version *and* the SHA256 of the published artifact so the
+# bundled JS is the exact bytes we reviewed — anything else (jsDelivr
+# regression, stale local copy, deliberate tampering) hard-fails the build.
 MERMAID_VERSION="11.4.1"
+MERMAID_SHA256="a43bc1afd446f9c4cc66ac5dd45d02e8d65e26fc5344ec0ef787f88d6ddb6f9e"
 MERMAID_JS="mdv/mermaid.min.js"
+
+verify_mermaid() {
+    local actual
+    actual="$(shasum -a 256 "$MERMAID_JS" | awk '{print $1}')"
+    if [ "$actual" != "$MERMAID_SHA256" ]; then
+        echo "✗ mermaid.min.js sha256 mismatch"
+        echo "  expected: $MERMAID_SHA256"
+        echo "  actual:   $actual"
+        echo "  delete $MERMAID_JS and re-run, or update MERMAID_SHA256 if"
+        echo "  you intentionally bumped MERMAID_VERSION."
+        exit 1
+    fi
+}
+
 if [ ! -f "$MERMAID_JS" ]; then
     echo "→ downloading mermaid.js $MERMAID_VERSION"
     curl -fsSL "https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/dist/mermaid.min.js" \
-         -o "$MERMAID_JS"
+         -o "$MERMAID_JS.tmp"
+    mv "$MERMAID_JS.tmp" "$MERMAID_JS"
 fi
+verify_mermaid
 cp "$MERMAID_JS"                 "$APP/Contents/Resources/"
 
 echo "→ codesigning (adhoc)"

--- a/mdv/Help.md
+++ b/mdv/Help.md
@@ -38,6 +38,17 @@ Every program eventually evolves bookmarks. We did not fight it.
 
 A frustrated, untalented graphic designer (the author) could not resist letting two LLMs argue with him about typography. The result is several themes. Pick one from the toolbar. Do not @ me about font choices.
 
+## Mermaid diagrams
+
+Fenced code blocks marked ` ```mermaid ` are rendered as diagrams, not source.
+
+- **Style picker** (palette icon, top-right of each diagram) — choose between Document (follows your current theme), Light, Dark, Tokyo Night, and Catppuccin. The choice is global and persists across restarts.
+- **Source toggle** (curly braces icon) — flip between the rendered diagram and the raw Mermaid source. The source view gets the same syntax highlighting as any other code block.
+- **Export** (download icon) — save the diagram as a PNG.
+- **Zoom** — pinch to zoom in on any diagram. Scroll to pan when zoomed.
+
+Flowcharts, sequence diagrams, class diagrams, ER diagrams, state diagrams, and XY charts render natively. Gantt charts and other diagram types render via a bundled mermaid.js — same toolbar, slightly slower first load.
+
 ## Editor integration
 
 - **⌘E** — open the current file in your external editor.

--- a/mdv/MermaidRenderer.swift
+++ b/mdv/MermaidRenderer.swift
@@ -102,11 +102,13 @@ struct MermaidCodeBlockChrome: View {
                 help: "Show Mermaid source"
             ) { showSource = true }
 
-            iconButton(
-                systemName: "square.and.arrow.down",
-                tinted: false,
-                help: "Export diagram as PNG"
-            ) { MDVMermaidImage.exportPNG(source: content, theme: theme, style: style) }
+            if nativeRenderer {
+                iconButton(
+                    systemName: "square.and.arrow.down",
+                    tinted: false,
+                    help: "Export diagram as PNG"
+                ) { MDVMermaidImage.exportPNG(source: content, theme: theme, style: style) }
+            }
 
             iconButton(
                 systemName: copied ? "checkmark" : "doc.on.doc",
@@ -227,9 +229,9 @@ struct MermaidCodeBlockChrome: View {
                 Menu("Diagram Style") {
                     stylePicker
                 }
-            }
-            Button("Export Diagram as PNG") {
-                MDVMermaidImage.exportPNG(source: content, theme: theme, style: style)
+                Button("Export Diagram as PNG") {
+                    MDVMermaidImage.exportPNG(source: content, theme: theme, style: style)
+                }
             }
         }
     }

--- a/mdv/MermaidRenderer.swift
+++ b/mdv/MermaidRenderer.swift
@@ -53,6 +53,12 @@ struct MermaidCodeBlockChrome: View {
     @State private var copied = false
     @State private var copyGeneration = 0
 
+    // The style picker only drives BeautifulMermaid's palette; the WKWebView
+    // fallback for gantt/pie/etc. honours just light/dark via mermaid.js's
+    // own theme. Showing the menu for those diagrams would mislead users
+    // into thinking it does something it can't.
+    private var nativeRenderer: Bool { isBeautifulMermaidSupported(content) }
+
     var body: some View {
         if showSource {
             sourceChrome
@@ -88,7 +94,7 @@ struct MermaidCodeBlockChrome: View {
 
     private var floatingToolbar: some View {
         HStack(spacing: 2) {
-            styleMenu
+            if nativeRenderer { styleMenu }
 
             iconButton(
                 systemName: "curlybraces",
@@ -217,8 +223,10 @@ struct MermaidCodeBlockChrome: View {
         if showSource {
             Button(wrap ? "Disable Wrap" : "Wrap Long Lines") { wrap.toggle() }
         } else {
-            Menu("Diagram Style") {
-                stylePicker
+            if nativeRenderer {
+                Menu("Diagram Style") {
+                    stylePicker
+                }
             }
             Button("Export Diagram as PNG") {
                 MDVMermaidImage.exportPNG(source: content, theme: theme, style: style)

--- a/mdv/MermaidRenderer.swift
+++ b/mdv/MermaidRenderer.swift
@@ -260,6 +260,16 @@ struct MermaidCodeBlockChrome: View {
     }
 }
 
+private func isBeautifulMermaidSupported(_ source: String) -> Bool {
+    let first = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        .split(separator: "\n", maxSplits: 1).first.map(String.init)?.lowercased() ?? ""
+    for prefix in ["flowchart", "graph ", "sequencediagram", "classdiagram",
+                   "erdiagram", "xychart", "statediagram"] {
+        if first.hasPrefix(prefix) { return true }
+    }
+    return false
+}
+
 struct MDVMermaidDiagramView: View {
     let source: String
     let theme: MDVTheme
@@ -275,29 +285,33 @@ struct MDVMermaidDiagramView: View {
     }
 
     var body: some View {
-        Group {
-            if let image {
-                diagramBody(for: image)
-            } else if failed {
-                MermaidFallbackView(source: source, theme: theme)
-            } else {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(maxWidth: .infinity, minHeight: 60)
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 16)
+        if isBeautifulMermaidSupported(source) {
+            Group {
+                if let image {
+                    diagramBody(for: image)
+                } else if failed {
+                    MermaidFallbackView(source: source, theme: theme)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(maxWidth: .infinity, minHeight: 60)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 16)
+                }
             }
-        }
-        .task(id: renderKey) {
-            failed = false
-            image = nil
-            zoom = 1
-            committedZoom = 1
-            if let rendered = await MDVMermaidImageCache.shared.image(source: source, theme: theme, style: style, key: renderKey) {
-                if !Task.isCancelled { image = rendered }
-            } else if !Task.isCancelled {
-                failed = true
+            .task(id: renderKey) {
+                failed = false
+                image = nil
+                zoom = 1
+                committedZoom = 1
+                if let rendered = await MDVMermaidImageCache.shared.image(source: source, theme: theme, style: style, key: renderKey) {
+                    if !Task.isCancelled { image = rendered }
+                } else if !Task.isCancelled {
+                    failed = true
+                }
             }
+        } else {
+            MermaidWebViewContainer(source: source, theme: theme)
         }
     }
 

--- a/mdv/MermaidRenderer.swift
+++ b/mdv/MermaidRenderer.swift
@@ -260,13 +260,73 @@ struct MermaidCodeBlockChrome: View {
     }
 }
 
-private func isBeautifulMermaidSupported(_ source: String) -> Bool {
-    let first = source.trimmingCharacters(in: .whitespacesAndNewlines)
-        .split(separator: "\n", maxSplits: 1).first.map(String.init)?.lowercased() ?? ""
-    for prefix in ["flowchart", "graph ", "sequencediagram", "classdiagram",
-                   "erdiagram", "xychart", "statediagram"] {
-        if first.hasPrefix(prefix) { return true }
+/// Returns the first line of `source` that is meaningful for diagram-type
+/// dispatch — i.e. not blank, not a `%%` comment, not a `%%{ init: … }%%`
+/// directive, and not inside a `--- … ---` frontmatter block. Lowercased.
+///
+/// Mermaid lets users put any combination of those preamble forms before
+/// the actual diagram keyword (`gantt`, `flowchart LR`, …); naively
+/// inspecting the first physical line therefore false-routes those
+/// diagrams into the WKWebView path even when BeautifulMermaid could
+/// render them natively.
+private func firstMermaidDirectiveLine(in source: String) -> String {
+    var inFrontmatter = false
+    var inDirective = false
+
+    for raw in source.split(separator: "\n", omittingEmptySubsequences: false) {
+        let line = raw.trimmingCharacters(in: .whitespaces)
+        if line.isEmpty { continue }
+
+        if inFrontmatter {
+            if line == "---" { inFrontmatter = false }
+            continue
+        }
+        if inDirective {
+            if line.contains("}%%") { inDirective = false }
+            continue
+        }
+
+        if line == "---" { inFrontmatter = true; continue }
+        if line.hasPrefix("%%{") {
+            // Single-line `%%{ init: … }%%` is consumed here; only flip the
+            // multi-line flag if the closer isn't on the same line.
+            if !line.contains("}%%") { inDirective = true }
+            continue
+        }
+        if line.hasPrefix("%%") { continue }
+
+        return line.lowercased()
     }
+    return ""
+}
+
+private func isBeautifulMermaidSupported(_ source: String) -> Bool {
+    let first = firstMermaidDirectiveLine(in: source)
+    if first.isEmpty { return false }
+
+    // Match the keyword exactly, or with any whitespace separator (spaces,
+    // tabs) before the diagram-specific arguments. Avoids the previous
+    // `"graph "` literal, which missed `graph\tLR` and bare `graph` on
+    // its own line, and avoids over-matching `graphfoo`.
+    func matches(_ keyword: String) -> Bool {
+        if first == keyword { return true }
+        guard first.hasPrefix(keyword) else { return false }
+        let next = first[first.index(first.startIndex, offsetBy: keyword.count)]
+        return next.isWhitespace
+    }
+
+    // BeautifulMermaid covers exactly these six families. `statediagram`
+    // matches both `stateDiagram` and `stateDiagram-v2`; same idea for
+    // `xychart` covering `xychart-beta`. `flowchart-elk` is intentionally
+    // *not* matched — ELK is a different layout backend that
+    // BeautifulMermaid doesn't speak.
+    if matches("flowchart") { return true }
+    if matches("graph") { return true }
+    if matches("sequencediagram") { return true }
+    if matches("classdiagram") { return true }
+    if matches("erdiagram") { return true }
+    if first.hasPrefix("statediagram") { return true } // statediagram-v2
+    if first.hasPrefix("xychart") { return true }      // xychart-beta
     return false
 }
 

--- a/mdv/MermaidRenderer.swift
+++ b/mdv/MermaidRenderer.swift
@@ -455,7 +455,7 @@ enum MDVMermaidImage {
     }
 }
 
-private struct MermaidFallbackView: View {
+struct MermaidFallbackView: View {
     let source: String
     let theme: MDVTheme
 

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -6,7 +6,12 @@ struct MermaidWebViewContainer: View {
     let source: String
     let theme: MDVTheme
 
-    @State private var height: CGFloat = 300
+    // Start small + show a spinner instead of holding a 300pt placeholder
+    // open until the first measurement arrives. The document then reflows
+    // exactly once — when mermaid actually reports the rendered SVG height
+    // — rather than jumping from 300 to the real value mid-scroll.
+    @State private var height: CGFloat = 60
+    @State private var measured = false
     @State private var failed = false
 
     var body: some View {
@@ -14,8 +19,15 @@ struct MermaidWebViewContainer: View {
             if failed {
                 MermaidFallbackView(source: source, theme: theme)
             } else {
-                MermaidWebView(source: source, theme: theme, height: $height, failed: $failed)
+                MermaidWebView(source: source, theme: theme,
+                               height: $height, measured: $measured, failed: $failed)
                     .frame(height: max(height, 60))
+                    .overlay {
+                        if !measured {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
             }
         }
         // Match the native renderer's accessibility surface
@@ -33,6 +45,7 @@ struct MermaidWebView: NSViewRepresentable {
     let source: String
     let theme: MDVTheme
     @Binding var height: CGFloat
+    @Binding var measured: Bool
     @Binding var failed: Bool
 
     struct LoadKey: Equatable {
@@ -60,7 +73,9 @@ struct MermaidWebView: NSViewRepresentable {
         return "rgb(\(r),\(g),\(b))"
     }
 
-    func makeCoordinator() -> Coordinator { Coordinator(height: $height, failed: $failed) }
+    func makeCoordinator() -> Coordinator {
+        Coordinator(height: $height, measured: $measured, failed: $failed)
+    }
 
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
@@ -154,12 +169,14 @@ struct MermaidWebView: NSViewRepresentable {
 
     final class Coordinator: NSObject, WKScriptMessageHandler {
         @Binding var height: CGFloat
+        @Binding var measured: Bool
         @Binding var failed: Bool
         var lastLoadKey: LoadKey?
         var lastMeasuredHeight: CGFloat?
 
-        init(height: Binding<CGFloat>, failed: Binding<Bool>) {
+        init(height: Binding<CGFloat>, measured: Binding<Bool>, failed: Binding<Bool>) {
             _height = height
+            _measured = measured
             _failed = failed
         }
 
@@ -184,7 +201,14 @@ struct MermaidWebView: NSViewRepresentable {
             // catches reloads, but suppressing micro-deltas keeps things calm.
             if let last = lastMeasuredHeight, abs(last - newHeight) < 0.5 { return }
             lastMeasuredHeight = newHeight
-            DispatchQueue.main.async { self.height = newHeight }
+            DispatchQueue.main.async {
+                self.height = newHeight
+                // First successful measurement: drop the ProgressView overlay.
+                // We never flip back to false on subsequent reloads (theme
+                // change, etc.) so the existing render stays on screen until
+                // the new one settles, instead of flashing a spinner.
+                if !self.measured { self.measured = true }
+            }
         }
     }
 }

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -6,10 +6,15 @@ struct MermaidWebViewContainer: View {
     let theme: MDVTheme
 
     @State private var height: CGFloat = 300
+    @State private var failed = false
 
     var body: some View {
-        MermaidWebView(source: source, theme: theme, height: $height)
-            .frame(height: max(height, 60))
+        if failed {
+            MermaidFallbackView(source: source, theme: theme)
+        } else {
+            MermaidWebView(source: source, theme: theme, height: $height, failed: $failed)
+                .frame(height: max(height, 60))
+        }
     }
 }
 
@@ -17,6 +22,7 @@ struct MermaidWebView: NSViewRepresentable {
     let source: String
     let theme: MDVTheme
     @Binding var height: CGFloat
+    @Binding var failed: Bool
 
     struct LoadKey: Equatable {
         let source: String
@@ -30,7 +36,7 @@ struct MermaidWebView: NSViewRepresentable {
         return js
     }()
 
-    func makeCoordinator() -> Coordinator { Coordinator(height: $height) }
+    func makeCoordinator() -> Coordinator { Coordinator(height: $height, failed: $failed) }
 
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
@@ -49,6 +55,10 @@ struct MermaidWebView: NSViewRepresentable {
         guard context.coordinator.lastLoadKey != key else { return }
         context.coordinator.lastLoadKey = key
         context.coordinator.lastMeasuredHeight = nil
+
+        // A previous render may have failed; we're loading fresh content,
+        // so clear the flag before the new render reports back.
+        DispatchQueue.main.async { self.failed = false }
 
         let html = buildHTML(source: source, isDark: theme.isDark)
         webView.loadHTMLString(html, baseURL: nil)
@@ -79,10 +89,14 @@ struct MermaidWebView: NSViewRepresentable {
           mermaid.initialize({ startOnLoad: false, theme: '\(mermaidTheme)' });
           mermaid.run().then(function() {
             var svg = document.querySelector('.mermaid svg');
-            var h = svg ? svg.getBoundingClientRect().height + 24 : -1;
-            window.webkit.messageHandlers.mermaidHeight.postMessage(h);
-          }).catch(function() {
-            window.webkit.messageHandlers.mermaidHeight.postMessage(-1);
+            if (svg) {
+              var h = svg.getBoundingClientRect().height + 24;
+              window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: true, height: h });
+            } else {
+              window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: false, error: 'no SVG produced' });
+            }
+          }).catch(function(err) {
+            window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: false, error: String(err) });
           });
         </script>
         </body>
@@ -92,14 +106,29 @@ struct MermaidWebView: NSViewRepresentable {
 
     final class Coordinator: NSObject, WKScriptMessageHandler {
         @Binding var height: CGFloat
+        @Binding var failed: Bool
         var lastLoadKey: LoadKey?
         var lastMeasuredHeight: CGFloat?
 
-        init(height: Binding<CGFloat>) { _height = height }
+        init(height: Binding<CGFloat>, failed: Binding<Bool>) {
+            _height = height
+            _failed = failed
+        }
 
         func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
             guard message.name == "mermaidHeight",
-                  let h = message.body as? Double, h > 0 else { return }
+                  let body = message.body as? [String: Any],
+                  let ok = body["ok"] as? Bool else { return }
+
+            if !ok {
+                DispatchQueue.main.async { self.failed = true }
+                return
+            }
+
+            guard let h = body["height"] as? Double, h > 0 else {
+                DispatchQueue.main.async { self.failed = true }
+                return
+            }
             let newHeight = CGFloat(h)
             // Avoid noise: only republish when the measurement materially
             // changes. SwiftUI re-renders are cheap, but the @State write here

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -18,6 +18,12 @@ struct MermaidWebView: NSViewRepresentable {
     let theme: MDVTheme
     @Binding var height: CGFloat
 
+    struct LoadKey: Equatable {
+        let source: String
+        let themeID: String
+        let isDark: Bool
+    }
+
     private static let mermaidJS: String = {
         guard let url = Bundle.main.url(forResource: "mermaid.min", withExtension: "js"),
               let js = try? String(contentsOf: url, encoding: .utf8) else { return "" }
@@ -35,6 +41,15 @@ struct MermaidWebView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
+        // Reload only when source/theme actually change. Without this guard,
+        // every SwiftUI update (including the height write we trigger from JS)
+        // would reload the page, which would re-measure and re-write height,
+        // creating a feedback loop — see CLAUDE.md.
+        let key = LoadKey(source: source, themeID: theme.id, isDark: theme.isDark)
+        guard context.coordinator.lastLoadKey != key else { return }
+        context.coordinator.lastLoadKey = key
+        context.coordinator.lastMeasuredHeight = nil
+
         let html = buildHTML(source: source, isDark: theme.isDark)
         webView.loadHTMLString(html, baseURL: nil)
     }
@@ -77,13 +92,22 @@ struct MermaidWebView: NSViewRepresentable {
 
     final class Coordinator: NSObject, WKScriptMessageHandler {
         @Binding var height: CGFloat
+        var lastLoadKey: LoadKey?
+        var lastMeasuredHeight: CGFloat?
 
         init(height: Binding<CGFloat>) { _height = height }
 
         func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
             guard message.name == "mermaidHeight",
                   let h = message.body as? Double, h > 0 else { return }
-            DispatchQueue.main.async { self.height = CGFloat(h) }
+            let newHeight = CGFloat(h)
+            // Avoid noise: only republish when the measurement materially
+            // changes. SwiftUI re-renders are cheap, but the @State write here
+            // is what feeds back into updateNSView; the LoadKey guard there
+            // catches reloads, but suppressing micro-deltas keeps things calm.
+            if let last = lastMeasuredHeight, abs(last - newHeight) < 0.5 { return }
+            lastMeasuredHeight = newHeight
+            DispatchQueue.main.async { self.height = newHeight }
         }
     }
 }

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -88,6 +88,16 @@ struct MermaidWebView: NSViewRepresentable {
         return webView
     }
 
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        // `WKUserContentController.add(_:name:)` retains the script-message
+        // handler. SwiftUI tears the representable down when the diagram
+        // scrolls out of identity, but the configuration's userContentController
+        // would keep the coordinator alive (with its bindings) until the
+        // WebView itself is collected. Explicit removal here keeps lifecycle
+        // honest and is the documented Apple pattern.
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "mermaidHeight")
+    }
+
     func updateNSView(_ webView: WKWebView, context: Context) {
         // Reload only when source/theme actually change. Without this guard,
         // every SwiftUI update (including the height write we trigger from JS)
@@ -134,7 +144,15 @@ struct MermaidWebView: NSViewRepresentable {
         <div class="mermaid">\(escaped)</div>
         <script>\(Self.mermaidJS)</script>
         <script>
-          mermaid.initialize({ startOnLoad: false, theme: '\(mermaidTheme)' });
+          // `securityLevel: 'strict'` is the mermaid.js default in v11, but
+          // pinning it here means the bundled JS can ship with whatever
+          // default it likes in the future without quietly downgrading the
+          // sandbox around user-supplied diagram source.
+          mermaid.initialize({
+            startOnLoad: false,
+            theme: '\(mermaidTheme)',
+            securityLevel: 'strict'
+          });
           mermaid.run().then(function() {
             var svg = document.querySelector('.mermaid svg');
             if (!svg) {

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -122,11 +122,26 @@ struct MermaidWebView: NSViewRepresentable {
           mermaid.initialize({ startOnLoad: false, theme: '\(mermaidTheme)' });
           mermaid.run().then(function() {
             var svg = document.querySelector('.mermaid svg');
-            if (svg) {
+            if (!svg) {
+              window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: false, error: 'no SVG produced' });
+              return;
+            }
+            function report() {
               var h = svg.getBoundingClientRect().height + 24;
               window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: true, height: h });
-            } else {
-              window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: false, error: 'no SVG produced' });
+            }
+            // Some diagram types (journey, quadrantChart, requirementDiagram)
+            // finalize their SVG dimensions *after* the run() promise resolves.
+            // A bare `getBoundingClientRect()` here returns a stale ~60pt
+            // height; waiting two animation frames lets the browser complete
+            // its first paint, and a ResizeObserver catches any further
+            // adjustments. The Swift side filters sub-pixel noise so the
+            // tail of ResizeObserver callbacks doesn't churn @State.
+            requestAnimationFrame(function() {
+              requestAnimationFrame(report);
+            });
+            if (typeof ResizeObserver !== 'undefined') {
+              new ResizeObserver(report).observe(svg);
             }
           }).catch(function(err) {
             window.webkit.messageHandlers.mermaidHeight.postMessage({ ok: false, error: String(err) });

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -10,12 +10,22 @@ struct MermaidWebViewContainer: View {
     @State private var failed = false
 
     var body: some View {
-        if failed {
-            MermaidFallbackView(source: source, theme: theme)
-        } else {
-            MermaidWebView(source: source, theme: theme, height: $height, failed: $failed)
-                .frame(height: max(height, 60))
+        Group {
+            if failed {
+                MermaidFallbackView(source: source, theme: theme)
+            } else {
+                MermaidWebView(source: source, theme: theme, height: $height, failed: $failed)
+                    .frame(height: max(height, 60))
+            }
         }
+        // Match the native renderer's accessibility surface
+        // (`MDVMermaidDiagramView.diagramBody` exposes the same label).
+        // The embedded WebView's own AX tree is opaque to VoiceOver, so
+        // collapsing this subtree to a single labeled element is more
+        // useful than leaking whatever the WebView happens to expose.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Mermaid diagram")
+        .accessibilityHint("Use Show Mermaid Source to view the diagram code.")
     }
 }
 

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import WebKit
 
@@ -36,13 +37,29 @@ struct MermaidWebView: NSViewRepresentable {
         return js
     }()
 
+    /// Render a SwiftUI `Color` as a CSS `rgb(...)` literal in sRGB so the
+    /// HTML body can be painted to match the surrounding chrome without a
+    /// transparent WebView. Falls back to `transparent` if the conversion
+    /// can't be done (which collapses to the WebView's default background
+    /// — uglier but never crashes the build).
+    static func cssColor(_ color: Color) -> String {
+        guard let ns = NSColor(color).usingColorSpace(.sRGB) else { return "transparent" }
+        let r = Int((ns.redComponent * 255).rounded())
+        let g = Int((ns.greenComponent * 255).rounded())
+        let b = Int((ns.blueComponent * 255).rounded())
+        return "rgb(\(r),\(g),\(b))"
+    }
+
     func makeCoordinator() -> Coordinator { Coordinator(height: $height, failed: $failed) }
 
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.userContentController.add(context.coordinator, name: "mermaidHeight")
         let webView = WKWebView(frame: .zero, configuration: config)
-        webView.setValue(false, forKey: "drawsBackground")
+        // We used to KVC `drawsBackground = false` here so the chrome's
+        // themed background showed through, but that's a private-API hack.
+        // Instead, paint the same color from inside the HTML body — see
+        // `buildHTML` — and let the WebView stay opaque.
         return webView
     }
 
@@ -60,16 +77,22 @@ struct MermaidWebView: NSViewRepresentable {
         // so clear the flag before the new render reports back.
         DispatchQueue.main.async { self.failed = false }
 
-        let html = buildHTML(source: source, isDark: theme.isDark)
+        let html = buildHTML(source: source, theme: theme)
         webView.loadHTMLString(html, baseURL: nil)
     }
 
-    private func buildHTML(source: String, isDark: Bool) -> String {
-        let mermaidTheme = isDark ? "dark" : "default"
+    private func buildHTML(source: String, theme: MDVTheme) -> String {
+        let mermaidTheme = theme.isDark ? "dark" : "default"
         let escaped = source
             .replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
+        // Match the chrome background painted by `MermaidCodeBlockChrome`
+        // (theme.secondaryBackground). The WebView itself is opaque now,
+        // so without this the diagram zone would show whatever the system
+        // default WebView background is and clash with the surrounding
+        // chrome on every dark-and-not-quite-black theme.
+        let bgCSS = Self.cssColor(theme.secondaryBackground)
         return """
         <!DOCTYPE html>
         <html>
@@ -77,7 +100,7 @@ struct MermaidWebView: NSViewRepresentable {
         <meta charset="UTF-8">
         <style>
           * { margin: 0; padding: 0; box-sizing: border-box; }
-          body { background: transparent; }
+          html, body { background: \(bgCSS); }
           .mermaid { padding: 12px 18px; }
           .mermaid svg { max-width: 100%; height: auto; display: block; }
         </style>

--- a/mdv/MermaidWebRenderer.swift
+++ b/mdv/MermaidWebRenderer.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import WebKit
+
+struct MermaidWebViewContainer: View {
+    let source: String
+    let theme: MDVTheme
+
+    @State private var height: CGFloat = 300
+
+    var body: some View {
+        MermaidWebView(source: source, theme: theme, height: $height)
+            .frame(height: max(height, 60))
+    }
+}
+
+struct MermaidWebView: NSViewRepresentable {
+    let source: String
+    let theme: MDVTheme
+    @Binding var height: CGFloat
+
+    private static let mermaidJS: String = {
+        guard let url = Bundle.main.url(forResource: "mermaid.min", withExtension: "js"),
+              let js = try? String(contentsOf: url, encoding: .utf8) else { return "" }
+        return js
+    }()
+
+    func makeCoordinator() -> Coordinator { Coordinator(height: $height) }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.userContentController.add(context.coordinator, name: "mermaidHeight")
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.setValue(false, forKey: "drawsBackground")
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        let html = buildHTML(source: source, isDark: theme.isDark)
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    private func buildHTML(source: String, isDark: Bool) -> String {
+        let mermaidTheme = isDark ? "dark" : "default"
+        let escaped = source
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="UTF-8">
+        <style>
+          * { margin: 0; padding: 0; box-sizing: border-box; }
+          body { background: transparent; }
+          .mermaid { padding: 12px 18px; }
+          .mermaid svg { max-width: 100%; height: auto; display: block; }
+        </style>
+        </head>
+        <body>
+        <div class="mermaid">\(escaped)</div>
+        <script>\(Self.mermaidJS)</script>
+        <script>
+          mermaid.initialize({ startOnLoad: false, theme: '\(mermaidTheme)' });
+          mermaid.run().then(function() {
+            var svg = document.querySelector('.mermaid svg');
+            var h = svg ? svg.getBoundingClientRect().height + 24 : -1;
+            window.webkit.messageHandlers.mermaidHeight.postMessage(h);
+          }).catch(function() {
+            window.webkit.messageHandlers.mermaidHeight.postMessage(-1);
+          });
+        </script>
+        </body>
+        </html>
+        """
+    }
+
+    final class Coordinator: NSObject, WKScriptMessageHandler {
+        @Binding var height: CGFloat
+
+        init(height: Binding<CGFloat>) { _height = height }
+
+        func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == "mermaidHeight",
+                  let h = message.body as? Double, h > 0 else { return }
+            DispatchQueue.main.async { self.height = CGFloat(h) }
+        }
+    }
+}

--- a/test-docs/README.md
+++ b/test-docs/README.md
@@ -33,6 +33,10 @@ history sidebar with the rest.
   setext H2) plus inline dash sequences that must *not* become rules.
   Useful for verifying thematic-break rendering with View → Smart
   Typography on and off.
+- [gantt.md](gantt.md) — a Mermaid `gantt` diagram. Rendered via
+  WKWebView + bundled mermaid.js (BeautifulMermaid does not support
+  this type). Use it to verify fallback rendering, light/dark theme
+  switching, and the source-view toggle.
 
 ## Quick checklist
 

--- a/test-docs/README.md
+++ b/test-docs/README.md
@@ -37,6 +37,13 @@ history sidebar with the rest.
   WKWebView + bundled mermaid.js (BeautifulMermaid does not support
   this type). Use it to verify fallback rendering, light/dark theme
   switching, and the source-view toggle.
+- [mermaid-web-fallback.md](mermaid-web-fallback.md) — one of every
+  other diagram type that goes through the WKWebView fallback (pie,
+  timeline, mindmap, journey, quadrant chart, requirement diagram)
+  plus a flowchart with a `%%{init}%%` directive and a `%%` comment
+  before the keyword to verify the native dispatcher still finds
+  it. If anything in here renders as the "could not be rendered"
+  plate, the type-detector is at fault.
 
 ## Quick checklist
 

--- a/test-docs/gantt.md
+++ b/test-docs/gantt.md
@@ -1,0 +1,58 @@
+## Gantt diagram
+
+```mermaid
+gantt
+    title Project Development Schedule
+    dateFormat YYYY-MM-DD
+    axisFormat %d/%m
+
+    section Kickoff
+    Project initialization         :done, 2025-06-21, 1d
+    API authentication             :done, 2025-06-30, 1d
+    Frontend authentication        :done, 2025-07-01, 1d
+    Kickoff call with stakeholders :milestone, done, 2025-07-03, 1d
+    CI/CD setup                    :done, 2025-07-05, 1d
+    🚀 First deploy!               :milestone, done, 2025-07-05, 1d
+
+    section Frontend
+    Onboarding, survey, home, daily tip (frontend) :done, 2025-07-02, 2025-07-06
+    Event detail page (frontend)                   :done, 2025-07-06, 2025-07-08
+    Compatibility section (frontend)               :done, 2025-07-07, 2025-07-09
+    Back button in TWA window                      :done, 2025-07-09, 1d
+    Profile section (view and edit) - frontend     :done, 2025-07-12, 2d
+    Glossary and FAQ pages                         :done, 2025-07-13, 1d
+    Favourites section (frontend)                  :done, 2025-07-20, 1d
+    Notifications page (frontend)                  :done, 2025-07-20, 1d
+
+    section Backend
+    Waiting for information from stakeholder :crit, 2025-07-07, 2025-07-24
+    City search API                          :done, 2025-07-11, 1d
+    User profile API                         :done, 2025-07-12, 1d
+    Day forecast - data model, API           :done, 2025-07-26, 1d
+    Day forecast - generation                :done, 2025-07-26, 1d
+    Redis client, global lock                :done, 2025-07-28, 3d
+    Daily tip - data model, API              :done, 2025-07-30, 1d
+    Compatibility - data model, API          :done, 2025-08-02, 2d
+    Compatibility - report generation        :done, 2025-08-03, 1d
+    Events - data model, API                 :done, 2025-08-06, 2d
+    Events - generation                      :done, 2025-08-07, 1d
+    Blocked: waiting on stakeholder          :crit, 2025-08-08, 4d
+    Subscriptions - data model, API          :done, 2025-08-31, 4d
+    Payment integration - stars              :done, 2025-09-06, 2d
+    ⏳ Payment integration - waiting         :crit, 2025-09-06, 2025-09-29
+    Payment integration - finalized          :done, 2025-10-03, 2d
+    Release preparation                      :done, 2025-10-06, 1d
+
+    section Integration
+    Day forecast - visualization    :done, 2025-07-26, 2025-07-28
+    Daily tip - visualization       :done, 2025-07-31, 1d
+    Compatibility - visualization   :done, 2025-08-04, 1d
+    Events - display                :done, 2025-08-07, 1d
+    Vacation                        :crit, 2025-08-18, 7d
+    Favourites - add, view, search  :done, 2025-08-29, 2d
+    Subscriptions - connect frontend:done, 2025-09-03, 3d
+    Payment - stars                 :done, 2025-09-06, 1d
+    ⏳ Payment - waiting            :crit, 2025-09-06, 2025-09-29
+    Payment - finalized             :done, 2025-10-03, 2d
+    Release preparation             :done, 2025-10-06, 1d
+```

--- a/test-docs/mermaid-web-fallback.md
+++ b/test-docs/mermaid-web-fallback.md
@@ -1,0 +1,130 @@
+# Mermaid WKWebView fallback
+
+A grab-bag of Mermaid diagram types BeautifulMermaid doesn't speak,
+all of which should render via the bundled `mermaid.min.js` running in
+a WKWebView. If any of them fall back to the "Mermaid diagram could
+not be rendered" plate, the dispatcher in `MermaidRenderer.swift` is
+miscategorising the keyword. If the diagram itself looks broken, that
+points at `MermaidWebRenderer.swift` or the bundled mermaid.js
+version pin in `build.sh`.
+
+Companion to [gantt.md](gantt.md), which exercises a single longer
+diagram. This file trades depth for breadth.
+
+## Pie
+
+```mermaid
+pie title Project time by area
+    "Engineering" : 45
+    "Design"      : 20
+    "Ops"         : 15
+    "Meetings"    : 20
+```
+
+## Timeline
+
+```mermaid
+timeline
+    title Release history
+    2024 : 0.1 — first commit
+         : 0.2 — themes
+    2025 : 0.5 — bookmarks
+         : 0.7 — Mermaid (native)
+    2026 : 0.8 — Mermaid (web fallback)
+```
+
+## Mindmap
+
+```mermaid
+mindmap
+  root((mdv))
+    Rendering
+      MarkdownUI
+      Tree-sitter
+      Mermaid
+        BeautifulMermaid
+        WKWebView fallback
+    UI
+      Sidebar
+      TOC
+      Bookmarks
+    Themes
+      Light
+      Dark
+      Reading
+```
+
+## User journey
+
+```mermaid
+journey
+    title A morning with mdv
+    section Open
+      Drag folder onto window: 5: User
+      Sidebar populates: 4: mdv
+    section Read
+      Skim README: 5: User
+      Click through cross-link: 5: User, mdv
+    section Edit
+      ⌘E into editor: 4: User
+      Save and live-reload: 5: mdv
+```
+
+## Quadrant chart
+
+```mermaid
+quadrantChart
+    title Feature triage
+    x-axis Hard --> Easy
+    y-axis Low impact --> High impact
+    quadrant-1 Do now
+    quadrant-2 Schedule
+    quadrant-3 Drop
+    quadrant-4 Quick wins
+    Mermaid web fallback: [0.7, 0.8]
+    Style picker for web path: [0.4, 0.3]
+    Snapshot-based PNG export: [0.2, 0.6]
+    Drop the KVC hack: [0.85, 0.55]
+```
+
+## Requirement diagram
+
+```mermaid
+requirementDiagram
+    requirement supported_types {
+        id: 1
+        text: BeautifulMermaid covers six diagram families.
+        risk: low
+        verifymethod: test
+    }
+
+    requirement web_fallback {
+        id: 2
+        text: Anything else renders via bundled mermaid.js.
+        risk: medium
+        verifymethod: demonstration
+    }
+
+    element dispatcher {
+        type: function
+    }
+
+    dispatcher - satisfies -> supported_types
+    dispatcher - satisfies -> web_fallback
+```
+
+## With a mermaid preamble
+
+This block opens with a `%%{init}%%` directive *and* a comment
+before the diagram keyword. The dispatcher should still see it as
+a flowchart and route it through the native path; if it ends up in
+the WKWebView fallback, `firstMermaidDirectiveLine` is broken.
+
+```mermaid
+%%{init: { "theme": "default" } }%%
+%% This is a comment, not a diagram keyword.
+flowchart LR
+    A[Source] --> B{Native?}
+    B -- yes --> C[BeautifulMermaid]
+    B -- no  --> D[WKWebView]
+```


### PR DESCRIPTION
I use Gantt charts a lot in my projects, so I was excited to finally have a comfortable way to view them in mdv — only to find out they weren't supported! Hence this PR. Please consider the proposed approach. I am ready to address any feedback or take a different approach to the implementation if necessary. The considered alternatives are described at the end of the PR.

## Summary

Mermaid fenced blocks whose diagram type isn't supported by BeautifulMermaid — `gantt`, `pie`, `timeline`, `mindmap`, and anything else added in the future — silently failed with "Mermaid diagram could not be rendered". This PR renders those types using the full `mermaid.js` library in an offscreen WKWebView, so the fallback message effectively disappears for all valid Mermaid source.

## Root cause

BeautifulMermaid supports exactly **6 diagram types**: flowchart, state, sequence, class, ER, and XY chart. Any other first-line keyword falls through to the flowchart parser, which chokes on the alien syntax (gantt tasks, date ranges, milestones), and `MDVMermaidImageCache.renderImage` returns `nil` via `try?`. `MDVMermaidDiagramView` then sets `failed = true` and shows `MermaidFallbackView`.

There is no gantt support in BeautifulMermaid's git history, and the library's own README states "6 diagram types" with no roadmap entry for gantt.

## Fix

Detect the diagram type from the first **meaningful** line before attempting BeautifulMermaid. The dispatcher (`firstMermaidDirectiveLine` + `isBeautifulMermaidSupported`) skips Mermaid preamble — frontmatter (`--- … ---`), `%%{ init: … }%%` directives, and `%% line comments` — so a flowchart with a title block still reaches the native pipeline. Keyword matching requires whitespace or end-of-line after the keyword, so `flowchart LR` and bare `flowchart` are accepted but `flowchart-elk` (a different layout backend BeautifulMermaid doesn't speak) is not.

Supported types go through the existing native pipeline unchanged. Everything else is handed to a new `MermaidWebViewContainer` that:

1. Loads an HTML page with the full `mermaid.js` (v11.4.1, bundled in `Contents/Resources/`) inlined as a `<script>`.
2. Runs `mermaid.run()` asynchronously.
3. Reports the rendered SVG height back to Swift via `window.webkit.messageHandlers.mermaidHeight` as a structured `{ ok, height | error }` payload, so SwiftUI can size the frame correctly after render and route mermaid.js parse failures back into the existing `MermaidFallbackView` (showing the "could not be rendered" header and the raw source) instead of leaving a blank box.

The WebView is opaque and the HTML body is painted with `theme.secondaryBackground` (the same color the surrounding chrome uses), so the diagram region matches the chrome on every theme without resorting to private WebKit KVC. `updateNSView` only reloads the page when `(source, themeID, isDark)` actually changes, so SwiftUI re-renders driven by the height write don't bounce back into a load loop. Toolbar items that only make sense for the native pipeline — the diagram-style picker and PNG export — are hidden on web-rendered diagrams; the source toggle, copy button, and accessibility label (matching the native `"Mermaid diagram"`) are kept.

## What changed

| File | Change |
|------|--------|
| `mdv/MermaidWebRenderer.swift` | New — `MermaidWebViewContainer` (SwiftUI view with dynamic height, fallback-on-failure, AX label) + `MermaidWebView: NSViewRepresentable` wrapping WKWebView with diff-based reload, themed body background, structured success/error messages |
| `mdv/MermaidRenderer.swift` | `firstMermaidDirectiveLine()` strips Mermaid preamble; `isBeautifulMermaidSupported()` matches keywords with whitespace/EOL boundaries; `MDVMermaidDiagramView.body` branches on it; `MermaidCodeBlockChrome` gates the style picker and PNG export on the dispatcher predicate; `MermaidFallbackView` promoted to internal so the web path can reuse it |
| `build.sh` | Downloads `mermaid.min.js` (pinned `MERMAID_VERSION="11.4.1"` + `MERMAID_SHA256`) on demand and verifies the SHA-256 of the cached file on every build — local drift or a CDN regression hard-fails |
| `.gitignore` | Exclude `mdv/mermaid.min.js` (downloaded asset, not committed) |
| `test-docs/gantt.md` | Generic English gantt test document |
| `test-docs/mermaid-web-fallback.md` | One example each of pie, timeline, mindmap, journey, quadrantChart, requirementDiagram, plus a flowchart with `%%{init}%%` + `%%` comment to lock in the preamble-stripping path |
| `README.md` | Add Mermaid to the features list (gap left by #29) |
| `mdv/Help.md` | New "Mermaid diagrams" section (gap left by #29) |
| `test-docs/README.md` | Add `gantt.md` and `mermaid-web-fallback.md` entries |

`mermaid.min.js` is **not** committed; the first build will fetch it. To pre-fetch:

```
./build.sh debug
```

## Test plan

Open `test-docs/gantt.md`:

- [x] Gantt diagram renders (sections, tasks, milestones, critical bars, emoji in task names) — **not** the "could not be rendered" fallback
- [x] Diagram respects light/dark theme (mermaid `default` theme in light, `dark` in dark) and matches the surrounding chrome background on every theme (no light/system slab behind the SVG on dark themes)
- [x] Curly-braces toolbar button toggles to Mermaid source view and back
- [x] Style picker and PNG export buttons are **hidden** on the gantt diagram (they only do work the WKWebView path can't honour)
- [x] Existing supported diagram types (any flowchart/sequence/class/ER/state/XY in the test suite) still render via BeautifulMermaid — native quality unchanged, full toolbar present
- [x] Switching themes re-renders the diagram once, not in a loop (no main-thread CPU spike, no flicker beyond the single transition)
- [x] Breaking the gantt source on purpose (e.g. typoing the keyword) shows the existing `MermaidFallbackView` plate with the source code, not a blank box

Open `test-docs/mermaid-web-fallback.md`:

- [x] pie / timeline / mindmap / journey / quadrantChart / requirementDiagram all render
- [x] The trailing flowchart (preceded by a `%%{init}%%` directive and a `%%` comment) renders via **BeautifulMermaid** — verifiable because its toolbar shows the style picker and PNG export

VoiceOver smoke check:

- [x] Web-rendered diagrams announce as "Mermaid diagram" (parity with the native path) instead of leaking the WebView's internal AX tree

**BEFORE** (gantt block, any theme):

<img width="1157" height="1193" alt="image" src="https://github.com/user-attachments/assets/5b65d4e3-511f-4cdf-ad4c-a6fbe95652ea" />

**AFTER**:

<img width="1157" height="1423" alt="image" src="https://github.com/user-attachments/assets/7a666ca3-e27c-4707-be91-8f5861f85dd0" />

<details>
<summary>Screenshots of other diagram types (pie / timeline / mindmap / journey / quadrantChart / requirementDiagram)</summary>

<img width="1094" height="1256" alt="image" src="https://github.com/user-attachments/assets/22c980cc-b684-4498-952a-cb25e6c6c91a" />
<img width="1094" height="1500" alt="image" src="https://github.com/user-attachments/assets/ff8211dc-bbd3-46eb-96aa-9d0f056a21a0" />
<img width="1094" height="808" alt="image" src="https://github.com/user-attachments/assets/03f54f1b-08a9-4e3d-a062-49efe049de52" />



</details>

## Alternatives considered

### 1. Implement gantt natively in Swift (not chosen)
Would require writing a full gantt parser (date arithmetic, task/milestone/section grammar, axisFormat, dateFormat) plus a renderer that produces correct bar widths and axis labels. That is essentially re-implementing a significant chunk of mermaid.js — hundreds of lines of error-prone layout code with no benefit over the reference JS implementation.

### 2. Fork BeautifulMermaid and add gantt (not chosen)
BeautifulMermaid is built around the ELK graph-layout engine, which is node-and-edge oriented. Gantt diagrams have no graph topology — they are time-series bars. Adding gantt would require a parallel rendering subsystem that bypasses ELK entirely, making it a near-standalone contribution to a third-party library.

### 3. WKWebView snapshot → NSImage (considered seriously)
Render in a hidden WKWebView, call `takeSnapshot(with:)`, and feed the result into the existing `MDVMermaidImageCache` pipeline. This would give gantt diagrams the same zoom/pan/export-PNG toolbar behaviour as native types. Rejected because: (a) getting the correct initial frame size before mermaid renders requires a two-pass layout — first load, wait for height message, resize, snapshot — which adds complexity and latency; (b) snapshot scale / retina handling needs manual wiring; (c) the inline WKWebView already auto-sizes correctly via the height message, so the added complexity buys little.

### 4. CDN-loaded mermaid.js (not chosen)
Drop the bundle, load from `cdn.jsdelivr.net` at render time. Saves ~3 MB from the download step but breaks offline use — a markdown viewer that fails to render diagrams when there's no Wi-Fi is a bad trade-off.

### 5. Vendoring `mermaid.min.js` into git (not chosen)
The simplest answer to "what bytes are we shipping?" is to commit them. Rejected because the file is 2.5 MB of minified third-party JS and would dominate the repo's churn whenever it's bumped. Pinning `MERMAID_VERSION` *and* `MERMAID_SHA256` in `build.sh` and verifying on every build (including the cached local file) gives the same integrity guarantee — a CDN regression, a stale dev cache, or a hand-edited copy all hard-fail the build with a pointer at the next step.

### 6. `webView.setValue(false, forKey: "drawsBackground")` (initially used, then removed)
The first cut made the WebView transparent so the chrome's themed background showed through. That's a private-API KVC poke; replaced by leaving the WebView opaque and painting the HTML body to `theme.secondaryBackground` from inside the page, which gives the same visual result on every macOS version without relying on undocumented WebKit behaviour.

### Chosen: inline WKWebView + bundled mermaid.js
Minimal new code, works offline, correct rendering guaranteed by the reference implementation, self-sizing via JS message passing, and integrity-checked at build time. The existing native pipeline for the 6 supported types is untouched.
