### PR TITLE
Thematic-break smart typography (#30) + O(n²) DoS fix

### DIFF
--- a/mdv/SmartTypography.swift
+++ b/mdv/SmartTypography.swift
@@ -53,10 +53,20 @@ func smartenMarkdown(_ source: String) -> String {
     // URL containing `(` like `https://en.wikipedia.org/wiki/Foo_(disambig)`
     // doesn't close early.
     var linkParenDepth = 0
-    var atLineStart = true
 
     while i < source.endIndex {
         let c = source[i]
+        // We are at the start of a logical line iff the last character we
+        // emitted was a newline (or nothing has been emitted yet). This is
+        // derived from `result` instead of tracked in a flag: every
+        // early-`continue` branch below would otherwise have to remember to
+        // clear the flag, and a single missed one lets the thematic-break
+        // look-ahead re-fire *mid*-line. On a long `-` run that is fatal —
+        // the em-dash branch advances by 3 but never reset the flag, so the
+        // look-ahead re-scanned the shrinking tail on every step: O(n^2)
+        // time and allocation, a hang on a crafted file. `result.last` is
+        // O(1), so this stays linear.
+        let atLineStart = result.isEmpty || result.last == "\n"
 
         // ---- Thematic break line (setext heading underline or standalone HR) ----
         // Emit verbatim so MarkdownUI can recognize it as a thematic break.
@@ -65,10 +75,9 @@ func smartenMarkdown(_ source: String) -> String {
             while end < source.endIndex && source[end] != "\n" {
                 end = source.index(after: end)
             }
-            if looksLikeThematicBreakLine(String(source[i..<end])) {
+            if looksLikeThematicBreakLine(source[i..<end]) {
                 result.append(contentsOf: source[i..<end])
                 i = end
-                atLineStart = false
                 continue
             }
         }
@@ -93,7 +102,6 @@ func smartenMarkdown(_ source: String) -> String {
         }
 
         if codeRun > 0 {
-            atLineStart = (c == "\n")
             result.append(c)
             i = source.index(after: i)
             continue
@@ -111,7 +119,6 @@ func smartenMarkdown(_ source: String) -> String {
             continue
         }
         if linkParenDepth > 0 {
-            atLineStart = (c == "\n")
             result.append(c)
             if c == "(" { linkParenDepth += 1 }
             else if c == ")" {
@@ -208,7 +215,6 @@ func smartenMarkdown(_ source: String) -> String {
             continue
         }
 
-        atLineStart = (c == "\n")
         result.append(c)
         i = source.index(after: i)
     }
@@ -219,7 +225,7 @@ func smartenMarkdown(_ source: String) -> String {
 /// True if `line` (one logical line, no `\n`) is a CommonMark thematic break:
 /// 3+ occurrences of the same marker (`-`, `*`, or `_`), with optional spaces/tabs,
 /// and nothing else. Examples: `---`, `----`, `* * *`, `- - -`.
-private func looksLikeThematicBreakLine(_ line: String) -> Bool {
+private func looksLikeThematicBreakLine(_ line: some StringProtocol) -> Bool {
     for marker: Character in ["-", "*", "_"] {
         let onlyMarkerAndSpace = line.allSatisfy { $0 == marker || $0 == " " || $0 == "\t" }
         if onlyMarkerAndSpace && line.filter({ $0 == marker }).count >= 3 {

--- a/mdv/SmartTypography.swift
+++ b/mdv/SmartTypography.swift
@@ -36,6 +36,11 @@ func smartenMarkdown(_ source: String) -> String {
         return source
     }
 
+    // Thematic break: entire block is a horizontal-rule line (--- / ---- / * * * / etc.)
+    if looksLikeThematicBreakLine(trimmed) {
+        return source
+    }
+
     var result = ""
     result.reserveCapacity(source.count)
 
@@ -48,9 +53,25 @@ func smartenMarkdown(_ source: String) -> String {
     // URL containing `(` like `https://en.wikipedia.org/wiki/Foo_(disambig)`
     // doesn't close early.
     var linkParenDepth = 0
+    var atLineStart = true
 
     while i < source.endIndex {
         let c = source[i]
+
+        // ---- Thematic break line (setext heading underline or standalone HR) ----
+        // Emit verbatim so MarkdownUI can recognize it as a thematic break.
+        if atLineStart && (c == "-" || c == "*" || c == "_") && codeRun == 0 {
+            var end = i
+            while end < source.endIndex && source[end] != "\n" {
+                end = source.index(after: end)
+            }
+            if looksLikeThematicBreakLine(String(source[i..<end])) {
+                result.append(contentsOf: source[i..<end])
+                i = end
+                atLineStart = false
+                continue
+            }
+        }
 
         // ---- Backtick runs (inline code spans) ----
         if c == "`" {
@@ -72,6 +93,7 @@ func smartenMarkdown(_ source: String) -> String {
         }
 
         if codeRun > 0 {
+            atLineStart = (c == "\n")
             result.append(c)
             i = source.index(after: i)
             continue
@@ -89,6 +111,7 @@ func smartenMarkdown(_ source: String) -> String {
             continue
         }
         if linkParenDepth > 0 {
+            atLineStart = (c == "\n")
             result.append(c)
             if c == "(" { linkParenDepth += 1 }
             else if c == ")" {
@@ -185,11 +208,25 @@ func smartenMarkdown(_ source: String) -> String {
             continue
         }
 
+        atLineStart = (c == "\n")
         result.append(c)
         i = source.index(after: i)
     }
 
     return result
+}
+
+/// True if `line` (one logical line, no `\n`) is a CommonMark thematic break:
+/// 3+ occurrences of the same marker (`-`, `*`, or `_`), with optional spaces/tabs,
+/// and nothing else. Examples: `---`, `----`, `* * *`, `- - -`.
+private func looksLikeThematicBreakLine(_ line: String) -> Bool {
+    for marker: Character in ["-", "*", "_"] {
+        let onlyMarkerAndSpace = line.allSatisfy { $0 == marker || $0 == " " || $0 == "\t" }
+        if onlyMarkerAndSpace && line.filter({ $0 == marker }).count >= 3 {
+            return true
+        }
+    }
+    return false
 }
 
 /// True iff the block contains a GFM table separator row — a line whose

--- a/test-docs/README.md
+++ b/test-docs/README.md
@@ -28,6 +28,11 @@ history sidebar with the rest.
 - [toc-stress.md](toc-stress.md) — many headings at every level so
   you can exercise the TOC pane, the spyglass-collapse search, and
   the "On this page" affordances.
+- [thematic-break.md](thematic-break.md) — every CommonMark
+  thematic-break variant (`---`, `----`, `* * *`, `_ _ _`, `- - -`,
+  setext H2) plus inline dash sequences that must *not* become rules.
+  Useful for verifying thematic-break rendering with View → Smart
+  Typography on and off.
 
 ## Quick checklist
 

--- a/test-docs/thematic-break.md
+++ b/test-docs/thematic-break.md
@@ -1,0 +1,64 @@
+# Thematic Break — rendering test
+
+Three hyphens (standard):
+
+---
+
+Four hyphens:
+
+----
+
+Five hyphens:
+
+-----
+
+Ten hyphens:
+
+----------
+
+Asterisks:
+
+***
+
+Underscores:
+
+___
+
+With spaces between:
+
+- - -
+
+* * *
+
+_ _ _
+
+---
+
+## Setext H2 heading
+
+The following heading uses a setext-style underline of hyphens:
+
+This is a second-level heading
+----
+
+This is a regular paragraph after it.
+
+---
+
+## Smart typography near rules
+
+This paragraph contains an em-dash via `---`: word --- word.
+
+And here a range via `--`: 2020--2025.
+
+These transformations should work as usual; only horizontal rules should render as lines, not text.
+
+---
+
+## Edge cases
+
+Hyphens inside text (must not become a rule):
+
+A line with hyphens in the middle: foo --- bar and foo ---- bar.
+
+CLI flags must not be touched: `--verbose` and `--output`.


### PR DESCRIPTION
## Attribution

This **carries forward @hazadus's #30** ("Fix thematic-break rendering when Smart Typography is enabled"). Both of @hazadus's original commits are included **unmodified, with their authorship intact** — this branch is stacked directly on top of them:

- `aa91dc2` Fix thematic-break rendering when Smart Typography is enabled — *@hazadus*
- `800fb3c` Document thematic-break.md in test-docs/README.md — *@hazadus*

The thematic-break fix and the test doc are entirely @hazadus's work and the credit for the feature is theirs. This PR adds **one** commit on top that fixes a denial-of-service issue found while reviewing #30. It is intended to **supersede #30** so the feature lands without the regression — please review/merge this and close #30, or merge #30 first and then this.

## The added fix — O(n²) hang on crafted input

The look-ahead introduced in #30 gates on a hand-tracked `atLineStart` flag that is cleared in only 3 of the ~9 early-`continue` branches of `smartenMarkdown`. The em-dash branch advances the cursor by 3 within a `-` run but never clears the flag, so the look-ahead re-fires after every em-dash and re-scans + re-allocates (`String(source[i..<end])`) the shrinking tail to end-of-line.

Result: **O(n²) time and allocation on a single long `-` line.** `smartenMarkdown` runs on the main thread in the SwiftUI view body (`ContentView.swift:2034`), and mdv auto-opens the most-recent file on launch and accepts drag-drop / ⌘O, so a crafted `.md` (tens of thousands of `-` followed by any non-marker char — which slips past the cheap whole-line guard) deterministically hangs the app. This is a **regression**: the same input was linear before #30.

Measured on the actual code (`-`×N then `x`, one line):

| N (≈ bytes) | #30 | this PR | pre-#30 (main) |
|---|---|---|---|
| 8 000  | 0.21s | 0.0009s | 0.001s |
| 32 000 | **3.40s** | 0.0037s | 0.003s |
| 128 000 | ~55s | 0.0147s | 0.010s |
| 512 000 | ~14 min (extrapolated) | 0.059s | — |

## Fix

Derive `atLineStart` once per loop iteration from the emitted output — `result.isEmpty || result.last == "\n"` (`result.last` is O(1)) — instead of a sticky flag mutated across branches. It is then correct regardless of which branch consumed the line, so the look-ahead fires **at most once per line** and the algorithm is linear again. Also passes the look-ahead slice as a `Substring` (helper now takes `some StringProtocol`) instead of allocating a `String` per call.

As a bonus this also closes two latent mis-fires the stale flag caused: `<br>---` and `...---` mid-line no longer wrongly suppress em-dash smartening.

## Test plan

No unit-test target exists in `mdv.xcodeproj` (project convention is manual `test-docs/`), so verification is a standalone harness over the compiled `SmartTypography.swift`:

- **Performance:** the table above — linear, doubling N ≈ doubles time; 512 KB of `-` in 0.06s.
- **Behavior unchanged:** all of #30's documented test-plan cases pass — standalone `---`/`----`/`* * *`, setext H2, setext-then-paragraph, `word --- word` → em-dash, `2020--2025` → en-dash, `foo --- bar` → em-dash, `` `--verbose` `` untouched, ellipsis, curly quotes, rule between paragraphs, bullet list not treated as a rule.
- Open `test-docs/thematic-break.md` with **View → Smart Typography on** — renders identically to #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)