### PR TITLE
Add Print support (⌘P) with block-aware pagination

### DIFF
--- a/mdv/CodeRenderer.swift
+++ b/mdv/CodeRenderer.swift
@@ -230,6 +230,10 @@ extension CodeSyntaxHighlighter where Self == MDVCodeSyntaxHighlighter {
 struct CodeBlockChrome: View {
     let configuration: CodeBlockConfiguration
     let theme: MDVTheme
+    /// Print rendering: force soft-wrap (paper can't scroll a horizontal
+    /// ScrollView — unwrapped long lines would silently truncate) and skip
+    /// the hover toolbar / context-menu machinery.
+    var forPrint: Bool = false
 
     @State private var hovering = false
     @State private var wrap = false
@@ -279,6 +283,13 @@ struct CodeBlockChrome: View {
                 theme: theme,
                 palette: palette
             )
+        } else if forPrint {
+            VStack(alignment: .leading, spacing: 0) {
+                chromeRow
+                codeContent
+            }
+            .background(palette.background ?? theme.secondaryBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 chromeRow
@@ -303,24 +314,26 @@ struct CodeBlockChrome: View {
 
             Spacer(minLength: 8)
 
-            HStack(spacing: 2) {
-                iconButton(
-                    systemName: wrap ? "text.alignleft" : "text.append",
-                    tinted: wrap,
-                    help: wrap ? "Disable wrap" : "Wrap long lines"
-                ) { wrap.toggle() }
+            if !forPrint {
+                HStack(spacing: 2) {
+                    iconButton(
+                        systemName: wrap ? "text.alignleft" : "text.append",
+                        tinted: wrap,
+                        help: wrap ? "Disable wrap" : "Wrap long lines"
+                    ) { wrap.toggle() }
 
-                iconButton(
-                    systemName: copied ? "checkmark" : "doc.on.doc",
-                    tinted: copied,
-                    help: copied ? "Copied" : "Copy code"
-                ) { copy() }
+                    iconButton(
+                        systemName: copied ? "checkmark" : "doc.on.doc",
+                        tinted: copied,
+                        help: copied ? "Copied" : "Copy code"
+                    ) { copy() }
+                }
+                .padding(.trailing, 6)
+                .opacity(hovering ? 1 : 0)
+                // Always reserve the toolbar's space so the label doesn't
+                // jitter when hover toggles. The opacity transition stays
+                // smooth without a layout shift.
             }
-            .padding(.trailing, 6)
-            .opacity(hovering ? 1 : 0)
-            // Always reserve the toolbar's space so the label doesn't
-            // jitter when hover toggles. The opacity transition stays
-            // smooth without a layout shift.
         }
         .frame(height: 26)
         .padding(.top, 4)
@@ -333,7 +346,7 @@ struct CodeBlockChrome: View {
 
     @ViewBuilder
     private var codeContent: some View {
-        if wrap {
+        if wrap || forPrint {
             configuration.label
                 .fixedSize(horizontal: false, vertical: true)
                 .relativeLineSpacing(.em(0.225))

--- a/mdv/ContentView.swift
+++ b/mdv/ContentView.swift
@@ -380,7 +380,8 @@ struct ContentView: View {
             forgetExternalEditor: { editorAppPath = "" },
             navigateBack: goBack,
             navigateForward: goForward,
-            toggleSidebar: toggleSidebar
+            toggleSidebar: toggleSidebar,
+            printDocument: printCurrentDocument
         ))
         .onOpenURL { url in
             loadFile(url)
@@ -1437,6 +1438,27 @@ struct ContentView: View {
         }
         flashClearWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: work)
+    }
+
+    // MARK: - Print
+
+    /// ⌘P / File > Print. Always prints in High Contrast (the light,
+    /// GitHub-style theme) regardless of the on-screen theme — classic
+    /// ink-friendly print behavior; the screen is untouched.
+    private func printCurrentDocument() {
+        guard !rawMarkdown.isEmpty else {
+            NSSound.beep()
+            return
+        }
+        let printTheme = MDVTheme.highContrast
+        PrintController.printDocument(PrintController.Request(
+            blocks: blocks,
+            jobTitle: selectedEntry?.filename ?? "mdv",
+            theme: printTheme,
+            baseURL: currentDocumentDirectory,
+            smartTypography: userSmartTypography && printTheme.smartTypographyAllowed,
+            window: NSApp.keyWindow
+        ))
     }
 
     // MARK: - Table of Contents
@@ -3044,6 +3066,7 @@ private struct NotificationHandlers: ViewModifier {
     let navigateBack: () -> Void
     let navigateForward: () -> Void
     let toggleSidebar: () -> Void
+    let printDocument: () -> Void
 
     func body(content: Content) -> some View {
         content
@@ -3066,6 +3089,7 @@ private struct NotificationHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .forgetExternalEditor)) { _ in forgetExternalEditor() }
             .onReceive(NotificationCenter.default.publisher(for: .navigateBack)) { _ in navigateBack() }
             .onReceive(NotificationCenter.default.publisher(for: .navigateForward)) { _ in navigateForward() }
+            .onReceive(NotificationCenter.default.publisher(for: .printDocument)) { _ in printDocument() }
     }
 }
 

--- a/mdv/PrintController.swift
+++ b/mdv/PrintController.swift
@@ -1,0 +1,395 @@
+import AppKit
+import MarkdownUI
+import SwiftUI
+
+/// Prints the rendered markdown document (⌘P → NSPrintOperation, whose
+/// dialog's PDF dropdown doubles as Save-as-PDF).
+///
+/// Strategy: re-render every block through the same MarkdownUI pipeline the
+/// screen uses, but via SwiftUI's `ImageRenderer` into one small vector PDF
+/// per block. A plain flipped NSView composites those PDF pages in
+/// `draw(_:)` and NSPrintOperation paginates it; `adjustPageHeightNew`
+/// pushes a block that would straddle a page break onto the next page, so
+/// breaks land in the gutters between blocks instead of through a line of
+/// text.
+///
+/// Why ImageRenderer and not NSHostingView: hosting views composite through
+/// the CoreAnimation render server, and their content never reaches
+/// AppKit's print drawing context from an offscreen window — they print
+/// blank. ImageRenderer renders without any window, and its CGContext path
+/// keeps text as vector glyphs in the final PDF.
+///
+/// Mermaid diagrams render asynchronously on screen (`.task` →
+/// MDVMermaidImageCache); ImageRenderer never runs async work, so mermaid
+/// blocks are pre-rendered to NSImages through the same cache before the
+/// view tree is built, and a fence whose render fails is re-tagged
+/// `mermaid` → `text` so it prints as a plain code block rather than as an
+/// empty box.
+@MainActor
+enum PrintController {
+
+    struct Request {
+        let blocks: [String]
+        let jobTitle: String
+        let theme: MDVTheme
+        let baseURL: URL?
+        /// Effective flag — caller has already ANDed the user preference
+        /// with the *print* theme's `smartTypographyAllowed`.
+        let smartTypography: Bool
+        /// Sheet parent. nil → app-modal dialog.
+        let window: NSWindow?
+    }
+
+    static func printDocument(_ request: Request) {
+        // A print sheet is already up — don't stack a second modal session.
+        guard activeSession == nil else {
+            NSSound.beep()
+            return
+        }
+        Task { @MainActor in
+            let mermaid = await preRenderMermaid(blocks: request.blocks, theme: request.theme)
+            // Leave the task context before building views or presenting the
+            // panel: the macOS 26 print panel is SwiftUI-backed and its view
+            // updates interrogate the current Swift-concurrency executor;
+            // presented from inside this short-lived Task it crashes
+            // (EXC_BAD_ACCESS in swift_task_isCurrentExecutor / DesignLibrary)
+            // once the task is gone. A plain main-queue callout has no task
+            // context to go stale. Reproduced 5/5 without this hop, 0/N with.
+            DispatchQueue.main.async {
+                let printInfo = makePrintInfo()
+                let container = buildContainer(request: request, mermaid: mermaid, printInfo: printInfo)
+                runOperation(container: container, printInfo: printInfo, request: request)
+            }
+        }
+    }
+
+    // MARK: - Print info
+
+    private static func makePrintInfo() -> NSPrintInfo {
+        let info = NSPrintInfo.shared.copy() as! NSPrintInfo
+        info.horizontalPagination = .fit
+        info.verticalPagination = .automatic
+        info.isHorizontallyCentered = false
+        info.isVerticallyCentered = false
+        info.topMargin = 54
+        info.bottomMargin = 54
+        info.leftMargin = 54
+        info.rightMargin = 54
+        // AppKit's standard header (job title + date) and footer (page
+        // numbers), fed by PrintContainerView.printJobTitle.
+        info.dictionary()[NSPrintInfo.AttributeKey.headerAndFooter] = NSNumber(value: true)
+        return info
+    }
+
+    // MARK: - Mermaid pre-pass
+
+    private struct MermaidPrePass {
+        var images: [Int: NSImage] = [:]
+        var failed: Set<Int> = []
+    }
+
+    private static func preRenderMermaid(blocks: [String], theme: MDVTheme) async -> MermaidPrePass {
+        // Same style preference MermaidCodeBlockChrome persists via
+        // @AppStorage("mdv.mermaid.style").
+        let style = UserDefaults.standard.string(forKey: "mdv.mermaid.style")
+            .flatMap(MermaidRenderStyle.init(rawValue:)) ?? .document
+        var result = MermaidPrePass()
+        for (idx, block) in blocks.enumerated() {
+            guard let source = mermaidSource(fromFencedBlock: block) else { continue }
+            let key = MDVMermaidRenderKey(source: source, theme: theme, style: style)
+            if let image = await MDVMermaidImageCache.shared.image(
+                source: source, theme: theme, style: style, key: key
+            ) {
+                result.images[idx] = image
+            } else {
+                result.failed.insert(idx)
+            }
+        }
+        return result
+    }
+
+    /// If `block` is a single fenced code block whose info string names
+    /// mermaid, returns the fence body; otherwise nil. The document's block
+    /// splitter is fence-aware, so a mermaid fence is exactly one block.
+    /// Language detection mirrors `CodeBlockChrome.displayLanguage` (first
+    /// token of the info string).
+    private static func mermaidSource(fromFencedBlock block: String) -> String? {
+        var lines = block.components(separatedBy: "\n")
+        guard let first = lines.first else { return nil }
+        let trimmed = first.drop(while: { $0 == " " })
+        let marker: String
+        if trimmed.hasPrefix("```") { marker = "```" }
+        else if trimmed.hasPrefix("~~~") { marker = "~~~" }
+        else { return nil }
+        let info = trimmed.dropFirst(3).trimmingCharacters(in: .whitespaces)
+        let language = info.split(separator: " ").first.map { $0.lowercased() } ?? ""
+        guard language == "mermaid" else { return nil }
+        lines.removeFirst()
+        // Tolerate an unterminated fence at EOF.
+        if let last = lines.last, last.drop(while: { $0 == " " }).hasPrefix(marker) {
+            lines.removeLast()
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Failed mermaid render → print the source as a plain code block.
+    /// Re-tagging the fence keeps it out of MermaidCodeBlockChrome (whose
+    /// diagram view renders via `.task` and would print as an empty box).
+    private static func retagMermaidFence(_ block: String) -> String {
+        var lines = block.components(separatedBy: "\n")
+        guard let first = lines.first,
+              let range = first.range(of: "mermaid", options: .caseInsensitive) else { return block }
+        lines[0] = first.replacingCharacters(in: range, with: "text")
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Container construction
+
+    private static func buildContainer(
+        request: Request,
+        mermaid: MermaidPrePass,
+        printInfo: NSPrintInfo
+    ) -> PrintContainerView {
+        let contentWidth = printInfo.paperSize.width
+            - printInfo.leftMargin - printInfo.rightMargin
+        let container = PrintContainerView(frame: .zero)
+        container.pageBackground = NSColor(request.theme.background)
+        container.jobTitle = request.jobTitle
+
+        // Screen rhythm: LazyVStack spacing 8 + each block's 2pt vertical
+        // hover padding × 2.
+        let spacing: CGFloat = 12
+        var y: CGFloat = 0
+        for (idx, block) in request.blocks.enumerated() {
+            let source = mermaid.failed.contains(idx) ? retagMermaidFence(block) : block
+            let markdown = request.smartTypography ? smartenMarkdown(source) : source
+            let root = PrintBlockView(
+                markdown: markdown,
+                mermaidImage: mermaid.images[idx],
+                theme: request.theme,
+                baseURL: request.baseURL
+            )
+            // Pinning the width inside the root view makes ImageRenderer
+            // report the ideal height at that width.
+            .frame(width: contentWidth, alignment: .topLeading)
+            .environment(\.colorScheme, request.theme.isDark ? .dark : .light)
+
+            guard let render = renderBlockPDF(root: AnyView(root), width: contentWidth) else {
+                continue
+            }
+            let frame = NSRect(x: 0, y: y, width: contentWidth, height: ceil(render.size.height))
+            container.blockRenders.append(
+                PrintContainerView.BlockRender(
+                    frame: frame, document: render.document, page: render.page
+                )
+            )
+            y += frame.height + spacing
+        }
+        container.frame = NSRect(x: 0, y: 0, width: contentWidth, height: max(y - spacing, 1))
+        return container
+    }
+
+    /// Renders one block view into a single-page vector PDF at the given
+    /// width, returning the PDF document, its first page, and the laid-out
+    /// size. Text stays vector all the way into the print/Save-as-PDF
+    /// output.
+    ///
+    /// The `document` is returned alongside the `page` and MUST be retained
+    /// for as long as the page is used: a `CGPDFPage` does not retain its
+    /// parent document, so dropping the document frees the page's backing
+    /// bytes and any later `drawPDFPage` is a use-after-free.
+    private static func renderBlockPDF(
+        root: AnyView, width: CGFloat
+    ) -> (document: CGPDFDocument, page: CGPDFPage, size: CGSize)? {
+        let renderer = ImageRenderer(content: root)
+        renderer.proposedSize = ProposedViewSize(width: width, height: nil)
+
+        var laidOutSize = CGSize.zero
+        let data = NSMutableData()
+        renderer.render { size, renderInContext in
+            laidOutSize = size
+            guard size.width > 0, size.height > 0,
+                  let consumer = CGDataConsumer(data: data as CFMutableData) else { return }
+            var mediaBox = CGRect(origin: .zero, size: size)
+            guard let ctx = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else { return }
+            ctx.beginPDFPage(nil)
+            renderInContext(ctx)
+            ctx.endPDFPage()
+            ctx.closePDF()
+        }
+        guard laidOutSize.width > 0, laidOutSize.height > 0,
+              let provider = CGDataProvider(data: data as CFData),
+              let document = CGPDFDocument(provider),
+              let page = document.page(at: 1) else { return nil }
+        return (document, page, laidOutSize)
+    }
+
+    // MARK: - Run
+
+    /// Keeps the container alive until the sheet-based print operation's
+    /// did-run callback — `runModal(for:...)` returns immediately, so
+    /// without this the view could be released mid-print.
+    @MainActor
+    private final class PrintSession: NSObject {
+        let container: PrintContainerView
+        var operation: NSPrintOperation?
+
+        init(container: PrintContainerView) {
+            self.container = container
+        }
+
+        // NSPrintOperation invokes the did-run selector on the main thread.
+        @objc func printOperationDidRun(
+            _ printOperation: NSPrintOperation,
+            success: Bool,
+            contextInfo: UnsafeMutableRawPointer?
+        ) {
+            PrintController.activeSession = nil
+        }
+    }
+
+    private static var activeSession: PrintSession?
+
+    private static func runOperation(
+        container: PrintContainerView,
+        printInfo: NSPrintInfo,
+        request: Request
+    ) {
+        let op = NSPrintOperation(view: container, printInfo: printInfo)
+        op.jobTitle = request.jobTitle
+        op.showsPrintPanel = true
+        op.showsProgressPanel = true
+        op.printPanel.options.formUnion([.showsPaperSize, .showsOrientation, .showsScaling])
+
+        if let parent = request.window {
+            let session = PrintSession(container: container)
+            session.operation = op
+            activeSession = session
+            op.runModal(
+                for: parent,
+                delegate: session,
+                didRun: #selector(PrintSession.printOperationDidRun(_:success:contextInfo:)),
+                contextInfo: nil
+            )
+        } else {
+            op.run()
+        }
+    }
+}
+
+// MARK: - Per-block print view
+
+/// Print-side equivalent of ContentView.blockView: the plain Markdown path
+/// only (no find highlights, hover stripes, or selection tints), scale
+/// fixed at 1.0 regardless of screen zoom, remote images forced to the
+/// blocked placeholder so nothing in the tree depends on async work.
+private struct PrintBlockView: View {
+    let markdown: String
+    let mermaidImage: NSImage?
+    let theme: MDVTheme
+    let baseURL: URL?
+
+    var body: some View {
+        if let image = mermaidImage {
+            // Mirrors MermaidCodeBlockChrome.diagramChrome / diagramBody
+            // (unzoomed), minus the hover toolbar.
+            Image(nsImage: image)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(
+                    image.size.height > 0 ? image.size.width / image.size.height : 1,
+                    contentMode: .fit
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 12)
+                .background(theme.resolvedCodePalette.background ?? theme.secondaryBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        } else {
+            Markdown(markdown)
+                .markdownTheme(theme.markdownTheme(scale: 1.0, forPrint: true))
+                .markdownCodeSyntaxHighlighter(.mdv(theme: theme))
+                .markdownImageProvider(LocalImageProvider(
+                    baseURL: baseURL,
+                    loadRemoteImages: false
+                ))
+        }
+    }
+}
+
+// MARK: - Container view
+
+/// Flipped canvas that composites the per-block vector PDF pages in
+/// `draw(_:)`. Pagination happens here: AppKit proposes a page bottom and
+/// `adjustPageHeightNew` moves it up to the nearest block boundary when a
+/// block would otherwise be sliced.
+final class PrintContainerView: NSView {
+    struct BlockRender {
+        /// Container coordinates (flipped: y grows downward), sorted top-down.
+        let frame: NSRect
+        /// Retained so `page` stays valid — a CGPDFPage does not retain its
+        /// parent document, and dropping the document frees the page's bytes.
+        let document: CGPDFDocument
+        let page: CGPDFPage
+    }
+
+    var blockRenders: [BlockRender] = []
+    var pageBackground: NSColor = .white
+    var jobTitle: String = "mdv"
+
+    override var isFlipped: Bool { true }
+
+    /// Feeds AppKit's standard print header.
+    override var printJobTitle: String { jobTitle }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        pageBackground.setFill()
+        dirtyRect.fill()
+        for block in blockRenders where block.frame.intersects(dirtyRect) {
+            ctx.saveGState()
+            // Block PDFs are y-up; the container is flipped. Anchor at the
+            // block's bottom edge and flip back to PDF coordinates.
+            ctx.translateBy(x: block.frame.minX, y: block.frame.maxY)
+            ctx.scaleBy(x: 1, y: -1)
+            ctx.drawPDFPage(block.page)
+            ctx.restoreGState()
+        }
+    }
+
+    /// How far a page break may be pulled up, as a fraction of the page.
+    /// AppKit's default is 0.2 — any block-boundary push larger than 20%
+    /// of a page would be clamped and the block sliced anyway. 0.9 lets
+    /// blocks up to ~90% of a page move wholesale to the next page.
+    override var heightAdjustLimit: CGFloat { 0.9 }
+
+    /// Flipped coordinates: y grows downward, `top < bottom`. `limit` is
+    /// the highest allowed break (`top + (1 − heightAdjustLimit) × pageHeight`)
+    /// — except on the document's final partial page, where AppKit still
+    /// computes it from the full page height and it can land BEYOND
+    /// `bottom`. The returned value must never exceed `bottom` ("*new not
+    /// set or increased" assertion), so the bottom clamp is applied last.
+    /// A block that straddles the proposed break and fits on a single page
+    /// moves wholesale to the next page; blocks taller than a page (or
+    /// starting exactly at the page top) slice at the default break.
+    override func adjustPageHeightNew(
+        _ newBottom: UnsafeMutablePointer<CGFloat>,
+        top oldTop: CGFloat,
+        bottom oldBottom: CGFloat,
+        limit bottomLimit: CGFloat
+    ) {
+        var proposed = oldBottom
+        let pageHeight = oldBottom - oldTop
+        for block in blockRenders {
+            let frame = block.frame
+            if frame.minY >= oldBottom { break }       // below the break — done
+            guard frame.maxY > oldBottom else { continue }  // fully above
+            // This block straddles the proposed page break.
+            if frame.height <= pageHeight && frame.minY > oldTop {
+                proposed = frame.minY
+            }
+            break
+        }
+        newBottom.pointee = min(max(proposed, bottomLimit), oldBottom)
+    }
+}

--- a/mdv/ThemeManager.swift
+++ b/mdv/ThemeManager.swift
@@ -414,7 +414,11 @@ extension MDVTheme {
     /// Heading sizes are em-relative so they scale automatically with body;
     /// per-element point spacing is left as-is to match browser-style zoom
     /// (text grows but the column doesn't change shape).
-    func markdownTheme(scale: CGFloat) -> Theme {
+    ///
+    /// `forPrint` reaches only the code-block chrome: printed code must
+    /// soft-wrap (no horizontal ScrollView on paper) and drops the hover
+    /// toolbar.
+    func markdownTheme(scale: CGFloat, forPrint: Bool = false) -> Theme {
         let bg = self.background
         let sbg = self.secondaryBackground
         let txt = self.text
@@ -554,7 +558,7 @@ extension MDVTheme {
                 // menu. Font + colors are set inside MDVCodeSyntaxHighlighter —
                 // the configuration.label here is the Text we produced and we
                 // don't apply markdownTextStyle font/size on top of it.
-                CodeBlockChrome(configuration: configuration, theme: self)
+                CodeBlockChrome(configuration: configuration, theme: self, forPrint: forPrint)
                     .markdownMargin(top: 0, bottom: 16)
             }
             .listItem { configuration in

--- a/mdv/mdvApp.swift
+++ b/mdv/mdvApp.swift
@@ -73,6 +73,12 @@ struct mdvApp: App {
                     }
                 }
             }
+            CommandGroup(replacing: .printItem) {
+                Button("Print…") {
+                    NotificationCenter.default.post(name: .printDocument, object: nil)
+                }
+                .keyboardShortcut("p", modifiers: .command)
+            }
             CommandGroup(after: .pasteboard) {
                 Divider()
                 Button("Find…") {
@@ -216,4 +222,5 @@ extension Notification.Name {
     static let navigateBack = Notification.Name("navigateBack")
     static let navigateForward = Notification.Name("navigateForward")
     static let toggleSidebar = Notification.Name("toggleSidebar")
+    static let printDocument = Notification.Name("printDocument")
 }


### PR DESCRIPTION
## What

File > Print… / **⌘P** prints the rendered markdown document. The macOS print dialog's PDF dropdown doubles as Save-as-PDF, so that ships too.

- Renders through the same MarkdownUI pipeline as the screen, always in the light **High Contrast** theme (ink-friendly regardless of the on-screen theme), at 100% scale (screen zoom ignored).
- **Page breaks land between blocks**: a custom `adjustPageHeightNew` pushes any block that would straddle a page onto the next page (`heightAdjustLimit` raised to 0.9 so pushes up to ~90% of a page are honored); only taller blocks get sliced.
- **Mermaid diagrams** pre-render to images through the existing `MDVMermaidImageCache` before the print view is built; a failed render re-tags the fence and prints as a plain code block.
- **Code blocks force soft-wrap** in print (`forPrint` flag through `markdownTheme` → `CodeBlockChrome`) — on screen they live in a horizontal ScrollView, which would truncate on paper. Hover toolbars are skipped; the language label stays.
- AppKit's standard header (filename + date) and footer (page numbers) are on, fed by a `printJobTitle` override.
- Empty document → beep, no dialog. Second ⌘P while the sheet is up → beep.

## How it works

Each block renders once into a small **vector PDF** via SwiftUI `ImageRenderer`; a flipped plain-NSView container composites those pages in `draw(_:)` and `NSPrintOperation` paginates it. This is the load-bearing design decision: `NSHostingView` content composites through the CoreAnimation render server and **never reaches AppKit's print drawing context** — printing hosting views offscreen yields blank pages (verified empirically). Text stays vector/selectable in the output.

## Crashes fixed during development

Three distinct bugs, each reproduced and re-verified headlessly:

1. **Use-after-free**: `CGPDFPage` does not retain its parent `CGPDFDocument`; `BlockRender` now retains both. Verified under `MallocScribble` + heap churn.
2. **Print panel crash at presentation**: the macOS 26 panel is SwiftUI-backed and crashed (stale-executor `EXC_BAD_ACCESS` in DesignLibrary) when presented from inside a short-lived `Task`. Presentation now hops to a plain main-queue callout with no task context. Reproduced 5/5 before, 0 after.
3. **Pagination assertion**: on the document's final partial page, AppKit passes `adjustPageHeightNew` a `limit` computed from the *full* page height, which can exceed `bottom`; returning it trips `'*new not set or increased'`. The result is now clamped to `bottom` last. Verified by invoking the panel's own `_validatePagination` across the full `test-docs/` corpus — clean on all five.

## Verification

Headless end-to-end runs (real app binary, real notification path): rendered PDFs inspected page-by-page across `test-docs/` — theme colors, smart typography (curly quotes), syntax highlighting, soft-wrapped long lines, tables with borders/alternating rows, local images, blocked-remote and missing-image placeholders, mermaid diagrams as crisp images. Pagination walked via AppKit's validator with zero block-straddling breaks. Interactive ⌘P → dialog → preview confirmed by @dccarroll on macOS 26.5.

Known v1 limitation: remote images print as the "Remote image blocked" placeholder (they load async; a pre-fetch pass is a noted follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)